### PR TITLE
Add SQLAlchemy VaultRepository and align vault_name column

### DIFF
--- a/app/alembic/versions/0dbbbaef458c_rename_nickname_to_vault_name.py
+++ b/app/alembic/versions/0dbbbaef458c_rename_nickname_to_vault_name.py
@@ -1,0 +1,35 @@
+"""Rename.nickname to vault_name
+
+Revision ID: 0dbbbaef458c
+Revises: a7a0a8f35224
+Create Date: 2026-01-23 18:57:30.272705
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0dbbbaef458c'
+down_revision = 'a7a0a8f35224'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "vaults",
+        "nickname",
+        new_column_name="vault_name",
+        existing_type=sa.String(),
+        existing_nullable=True,
+    )
+
+def downgrade() -> None:
+    op.alter_column(
+        "vaults",
+        "vault_name",
+        new_column_name="nickname",
+        existing_type=sa.String(),
+        existing_nullable=True,
+    )

--- a/app/infrastructure/db/models/vault_orm.py
+++ b/app/infrastructure/db/models/vault_orm.py
@@ -13,7 +13,7 @@ class VaultORM(Base):
     id: Mapped[str] = mapped_column(String, primary_key=True)
     owner_id: Mapped[str] = mapped_column(String, nullable=False)
     hardware_uuid: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
-    nickname: Mapped[str | None] = mapped_column(String, nullable=True)
+    vault_name: Mapped[str | None] = mapped_column(String, nullable=True)
     status: Mapped[str] = mapped_column(String, nullable=False)
     last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/app/infrastructure/db/repositories/sqlalchemy_vault_repository.py
+++ b/app/infrastructure/db/repositories/sqlalchemy_vault_repository.py
@@ -1,0 +1,68 @@
+from sqlalchemy.orm import Session
+
+from app.application.services.vault_repository import VaultRepository
+from app.infrastructure.db.models.vault_orm import VaultORM
+from app.domain.models.vault import Vault
+from app.domain.value_objects.vault_status import VaultStatus
+
+
+class SqlAlchemyVaultRepository(VaultRepository):
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        
+    def get_by_id(self, vault_id: str) -> Vault | None:
+        row = self._session.get(VaultORM, vault_id)
+        if row is None:
+            return None
+
+        return Vault(
+            id=row.id,
+            owner_id=row.owner_id,
+            hardware_uuid=row.hardware_uuid,
+            vault_name=row.vault_name,
+            status=VaultStatus(row.status),
+            last_seen_at=row.last_seen_at,
+        )
+        
+    def get_by_hardware_uuid(self, hardware_uuid: str) -> Vault | None:
+        row = (
+            self._session.query(VaultORM)
+            .filter(VaultORM.hardware_uuid == hardware_uuid)
+            .one_or_none()
+        )
+        if row is None:
+            return None
+
+        return Vault(
+            id=row.id,
+            owner_id=row.owner_id,
+            hardware_uuid=row.hardware_uuid,
+            vault_name=row.vault_name,
+            status=VaultStatus(row.status),
+            last_seen_at=row.last_seen_at,
+        )
+        
+    def create(self, vault: Vault) -> Vault:
+        row = VaultORM(
+            id=vault.id,
+            owner_id=vault.owner_id,
+            hardware_uuid=vault.hardware_uuid,
+            vault_name=vault.vault_name,
+            status=vault.status.value,
+            last_seen_at=vault.last_seen_at,
+        )
+
+        self._session.add(row)
+        self._session.commit()
+        self._session.refresh(row)
+
+        return Vault(
+            id=row.id,
+            owner_id=row.owner_id,
+            hardware_uuid=row.hardware_uuid,
+            vault_name=row.vault_name,
+            status=VaultStatus(row.status),
+            last_seen_at=row.last_seen_at,
+        )
+
+


### PR DESCRIPTION
This PR introduces a SQLAlchemy-backed implementation of VaultRepository.

Changes:
- Added SqlAlchemyVaultRepository with get/create methods
- Renamed vaults.nickname → vaults.vault_name across ORM and DB
- Added Alembic migration for column rename
- Kept InMemoryVaultRepository as default (no DI changes yet)

Notes:
- No runtime behavior change
- Tests remain green
- Prepares groundwork for switching to Postgres-backed repository


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated vault field naming from nickname to vault_name in the database schema for consistency.
  * Implemented a new repository layer for vault data access and persistence.

* **Database**
  * Applied database migration to rename vault identifier field with rollback support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->