### PR TITLE
Fix PBKDF2 verify to safely handle malformed hashes

### DIFF
--- a/app/application/services/password_hasher_service.py
+++ b/app/application/services/password_hasher_service.py
@@ -32,6 +32,9 @@ class PBKDF2PasswordHasher:
         )
 
     def verify(self, raw_password: str, encoded: str) -> bool:
+        if not isinstance(encoded, str):
+            return False
+
         try:
             scheme, iters_s, salt_b64, dk_b64 = encoded.split("$", 3)
             if scheme != "pbkdf2":
@@ -43,7 +46,9 @@ class PBKDF2PasswordHasher:
 
             salt = base64.urlsafe_b64decode(salt_b64.encode("ascii"))
             expected = base64.urlsafe_b64decode(dk_b64.encode("ascii"))
-        except (ValueError, TypeError, binascii.Error):
+            if not salt or not expected:
+                return False
+        except (ValueError, TypeError, AttributeError, binascii.Error):
             return False
 
         actual = hashlib.pbkdf2_hmac(
@@ -54,4 +59,3 @@ class PBKDF2PasswordHasher:
             dklen=len(expected),
         )
         return hmac.compare_digest(actual, expected)
-

--- a/app/tests/application/test_password_hasher_service.py
+++ b/app/tests/application/test_password_hasher_service.py
@@ -4,6 +4,20 @@ from app.application.services.password_hasher_service import PBKDF2PasswordHashe
 def test_verify_returns_false_on_malformed_hash():
     hasher = PBKDF2PasswordHasher(iterations=10_000)
 
+    # malformed formats
     assert hasher.verify("pw", "not-a-hash") is False
     assert hasher.verify("pw", "pbkdf2$nope$salt$dk") is False
     assert hasher.verify("pw", "pbkdf2$-1$c2FsdA==$ZGs=") is False
+
+    # non-string encoded value
+    assert hasher.verify("pw", None) is False  # type: ignore[arg-type]
+
+    # empty decoded expected (dklen == 0 case)
+    assert hasher.verify("pw", "pbkdf2$1$c2FsdA==$") is False
+    
+def test_verify_happy_path():
+    hasher = PBKDF2PasswordHasher(iterations=10_000)
+    encoded = hasher.hash("correct-horse-battery-staple")
+    assert hasher.verify("correct-horse-battery-staple", encoded) is True
+    assert hasher.verify("wrong-password", encoded) is False
+


### PR DESCRIPTION
### Summary
Hardens PBKDF2 password verification to never throw on malformed input.

### Changes
- Return False for non-string, malformed, or empty decoded hash values
- Guard against dklen=0 and invalid iteration values
- Add regression tests for malformed and edge-case inputs

### Notes
- No behavior change for valid hashes
- Addresses follow-up review feedback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced password verification with improved input validation and error handling. The system now correctly processes edge cases such as malformed hash formats and invalid inputs, ensuring reliable authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->