### PR TITLE
test(infra): fix redis asyncio loop leakage in tests

### DIFF
--- a/.tmp_patch_email.py
+++ b/.tmp_patch_email.py
@@ -1,4 +1,4 @@
 from pathlib import Path
 p = Path('app/infrastructure/notifications/email_service.py')
 text = p.read_text()
-old = 'log.info(
+old = 'log.info('

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -30,7 +30,7 @@ async def verify_otp(
         ticket = await otp_svc.verify_otp_and_issue_ticket(payload.email, payload.otp)
         return OTPVerifyResponse(signup_ticket=ticket)
     except OTPInvalidError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 @router.post("/signup", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 async def signup(
@@ -56,6 +56,6 @@ async def signup(
         return UserResponse.model_validate(user)
 
     except TicketInvalidError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except DuplicateEmailError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))

--- a/app/infrastructure/services/otp_ticket_service.py
+++ b/app/infrastructure/services/otp_ticket_service.py
@@ -29,7 +29,7 @@ class OTPTicketService:
     _OTP_CONSUME_LUA = """
 local current = redis.call('GET', KEYS[1])
 if not current then return nil end
-if current ~= ARGV[1] then return false end
+if current ~= ARGV[1] then return 0 end
 -- prefer GETDEL when available (Redis >= 6.2)
 local ok, val = pcall(redis.call, 'GETDEL', KEYS[1])
 if ok then
@@ -42,7 +42,7 @@ return current
     _TICKET_CONSUME_LUA = """
 local current = redis.call('GET', KEYS[1])
 if not current then return nil end
-if current ~= ARGV[1] then return false end
+if current ~= ARGV[1] then return 0 end
 local ok, val = pcall(redis.call, 'GETDEL', KEYS[1])
 if ok then
   return val
@@ -66,12 +66,12 @@ return current
         await redis_setex(self._otp_key(email), settings.OTP_TTL_SECONDS, otp.encode("utf-8"))
         return OTPResult(otp=otp)
 
-    async def _consume_otp_value(self, key: str, expected: str) -> bytes | None | bool:
+    async def _consume_otp_value(self, key: str, expected: str) -> bytes | None | int:
         """Atomically read-and-delete the OTP value only when it matches expected.
 
         Returns:
             bytes: the consumed value when matched and deleted
-            False: when value exists but does not match expected
+            0: when value exists but does not match expected
             None: when key is missing/expired
         """
         redis = await get_redis()
@@ -84,11 +84,11 @@ return current
             if value is None:
                 return None
             if value.decode("utf-8") != expected:
-                return False
+                return 0
             await redis.delete(key)
             return value
 
-    async def _consume_ticket_value(self, key: str, expected: str) -> bytes | None | bool:
+    async def _consume_ticket_value(self, key: str, expected: str) -> bytes | None | int:
         """Atomically read-and-delete the signup ticket only when it matches expected email."""
         redis = await get_redis()
         try:
@@ -100,7 +100,7 @@ return current
             if value is None:
                 return None
             if value.decode("utf-8") != expected:
-                return False
+                return 0
             await redis.delete(key)
             return value
 
@@ -110,7 +110,7 @@ return current
 
         if result is None:
             raise OTPInvalidError("OTP expired or not found")
-        if result is False or (isinstance(result, bytes) and result.decode("utf-8") != otp):
+        if result == 0 or (isinstance(result, bytes) and result.decode("utf-8") != otp):
             raise OTPInvalidError("Invalid OTP")
 
         ticket = secrets.token_urlsafe(32)
@@ -129,7 +129,7 @@ return current
         if result is None:
             raise TicketInvalidError("Signup ticket expired or invalid")
 
-        if result is False or (isinstance(result, bytes) and result.decode("utf-8") != expected):
+        if result == 0 or (isinstance(result, bytes) and result.decode("utf-8") != expected):
             raise TicketInvalidError("Signup ticket does not match email")
 
         # success path: ticket already deleted atomically

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -13,8 +13,13 @@ from app.infrastructure.cache.redis_client import redis_shutdown
 
 @pytest.fixture
 def app():
+    previous = settings.DEV_AUTH_BYPASS
     settings.DEV_AUTH_BYPASS = True
-    return create_app()
+    app = create_app()
+    try:
+        yield app
+    finally:
+        settings.DEV_AUTH_BYPASS = previous
 
 
 @pytest.fixture(autouse=True)

--- a/app/tests/services/test_otp_ticket_service.py
+++ b/app/tests/services/test_otp_ticket_service.py
@@ -38,7 +38,7 @@ async def test_verify_otp_consumes_once_atomically():
 async def test_wrong_otp_does_not_consume():
     svc = OTPTicketService()
     email = "wrong@example.com"
-    otp = (await svc.issue_otp(email)).otp
+    await svc.issue_otp(email)
 
     with pytest.raises(OTPInvalidError):
         await svc.verify_otp_and_issue_ticket(email, "000000")


### PR DESCRIPTION
## Summary
This PR implements a secure OTP-based signup flow using one-time signup tickets, with production-safe email handling and strong concurrency guarantees.

## Related Issues
Closes #32 

## Key Features
- OTP request → verification → one-time signup ticket flow
- Atomic OTP verification and ticket consumption using Redis Lua
- Configurable email backend (dev vs SMTP)
- Secure handling of sensitive data (no raw OTP logging)
- Dev-only auth bypass guarded by explicit configuration
- Improved test isolation for Redis asyncio clients

## Security Improvements
- Prevents OTP reuse under concurrent requests
- Prevents signup ticket replay attacks
- Eliminates sensitive OTP leakage via logs
- Guards dev-only authentication behavior

## Configuration Notes
- `EMAIL_BACKEND=dev|smtp`
- `DEV_AUTH_BYPASS=true` (dev/test only)
- SMTP settings required when `EMAIL_BACKEND=smtp`

## Testing
- Added unit tests for OTP atomicity
- Added API tests for full signup flow
- All tests pass (`pytest`)

## Follow-ups (out of scope)
- JWT/session-based authentication
- Rate limiting OTP requests
- Email template rendering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated API error responses for OTP verification and signup ticket validation to use HTTP 422 Unprocessable Content status code.

* **Tests**
  * Enhanced test fixture initialization and cleanup for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->