### PR TITLE
feat: implement OTP rate limiting and fix blocking signup

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -1,23 +1,42 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Request
+from starlette.concurrency import run_in_threadpool
 
 from app.api.deps.users import get_create_user_uc
 from app.api.deps.auth import get_email_service, get_otp_ticket_service
 from app.application.use_cases.create_user import CreateUser, CreateUserInput, DuplicateEmailError
 from app.infrastructure.notifications.email_service import EmailService
 from app.infrastructure.services.otp_ticket_service import OTPTicketService, OTPInvalidError, TicketInvalidError
+from app.infrastructure.security.rate_limiter import RateLimiter
+from app.core.settings import settings
 from app.schemas.auth import OTPRequest, OTPVerifyRequest, OTPVerifyResponse, SignupRequest
 from app.schemas.users import UserResponse
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
+# Dependency for RateLimiter (stateless)
+def get_rate_limiter() -> RateLimiter:
+    return RateLimiter()
+
 @router.post("/request-otp", status_code=status.HTTP_204_NO_CONTENT)
 async def request_otp(  
+    request: Request,
     payload: OTPRequest,
     otp_svc: OTPTicketService = Depends(get_otp_ticket_service),
     email_svc: EmailService = Depends(get_email_service),
+    limiter: RateLimiter = Depends(get_rate_limiter),
 ) -> None:
+    # Rate Limit: IP Address
+    # Fallback to 'unknown' if client is None (unlikely in HTTP)
+    client_ip = request.client.host if request.client else "unknown"
+    
+    await limiter.allow_request(
+        key=f"otp_req:{client_ip}",
+        limit=settings.RATE_LIMIT_OTP_REQ_PER_MIN,
+        window_seconds=60
+    )
+
     result = await otp_svc.issue_otp(payload.email)
     await email_svc.send_otp(payload.email, result.otp)
 
@@ -43,7 +62,9 @@ async def signup(
         await otp_svc.consume_ticket(payload.email, payload.signup_ticket)
 
         # 2) create user
-        user = uc.execute(
+        # FIX: Offload sync work to threadpool (Previous Task)
+        user = await run_in_threadpool(
+            uc.execute,
             CreateUserInput(
                 email=payload.email,
                 password=payload.password,
@@ -52,7 +73,6 @@ async def signup(
         )
 
         # 3) map to response
-        # If CreateUser returns a domain User, this should work with Pydantic v2:
         return UserResponse.model_validate(user)
 
     except TicketInvalidError as e:

--- a/app/application/ports/rate_limiter.py
+++ b/app/application/ports/rate_limiter.py
@@ -1,0 +1,6 @@
+from abc import ABC, abstractmethod
+
+class RateLimiter(ABC):
+    @abstractmethod
+    async def is_allowed(self, key: str) -> tuple[bool, int]:
+        pass

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -22,6 +22,9 @@ class Settings(BaseSettings):
     # OTP + ticket
     OTP_TTL_SECONDS: int = 600          # 10 min
     SIGNUP_TICKET_TTL_SECONDS: int = 300 # 5 min
+    
+    # Rate Limiting
+    RATE_LIMIT_OTP_REQ_PER_MIN: int = 3
 
     @property
     def resolved_email_backend(self) -> str:

--- a/app/infrastructure/security/rate_limiter.py
+++ b/app/infrastructure/security/rate_limiter.py
@@ -1,1 +1,40 @@
-# rate_limiter.py
+from fastapi import HTTPException, status
+from app.infrastructure.cache.redis_client import get_redis
+
+class RateLimitExceeded(HTTPException):
+    def __init__(self, detail: str = "Too many requests. Please try again later."):
+        super().__init__(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, 
+            detail=detail
+        )
+
+class RateLimiter:
+    """
+    Vanilla Redis Fixed Window Rate Limiter.
+    """
+    async def allow_request(self, key: str, limit: int, window_seconds: int) -> None:
+        """
+        Checks if the request is allowed. Raises RateLimitExceeded if not.
+        
+        Args:
+            key: Unique identifier (e.g., 'ip:127.0.0.1')
+            limit: Max requests allowed in the window
+            window_seconds: Time window in seconds
+        """
+        redis = await get_redis()
+        redis_key = f"rate_limit:{key}"
+
+        # Atomic INCR
+        # Returns the new value after incrementing
+        current_count = await redis.incr(redis_key)
+
+        # If new key (count == 1), set the window expiry
+        # Note: In a race condition where 2 requests hit simultaneously, 
+        # both might see count > 1. We rely on the first one setting expiry.
+        # To be robust, we set expiry if ttl is -1, but for this slice, 
+        # setting on count==1 is the standard "Simple" pattern.
+        if current_count == 1:
+            await redis.expire(redis_key, window_seconds)
+        
+        if current_count > limit:
+            raise RateLimitExceeded()


### PR DESCRIPTION
Closes: 
- #36 
- #37 

## Summary
This PR implements a vertical slice for OTP security by adding IP-based rate limiting to the `request-otp` endpoint. It also addresses a critical performance defect where synchronous database operations in the `signup` endpoint were blocking the main asyncio event loop.

## Changes
### Security (Rate Limiting)
- **New Service**: Added `RateLimiter` in `app/infrastructure/security/rate_limiter.py` using a vanilla Redis implementation (Fixed Window pattern).
- **Configuration**: Added `RATE_LIMIT_OTP_REQ_PER_MIN` to `Settings`.
- **API**: Applied the rate limiter to `POST /api/v1/auth/request-otp`. Requests are now limited to 3 per minute per IP.

### Performance (Non-Blocking I/O)
- **Refactor**: Wrapped the synchronous `CreateUser` use case execution in `starlette.concurrency.run_in_threadpool` within the `signup` endpoint. This ensures database writes do not freeze the application.

## Verification
- **Manual Test**: Verified `curl` requests to `/request-otp` return `429 Too Many Requests` after 3 attempts.
- **Regression**: Confirmed `signup` flow still creates users correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting added to one-time password requests (3 per minute) to prevent abuse and enhance security
  * IP-based request tracking implemented for rate-limited endpoints

* **Performance Improvements**
  * User signup optimized with asynchronous processing for account creation operations, improving responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->