### PR TITLE
feat: implement secure OTP signup flow with rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ make redis-flush   # DEV ONLY: flush Redis DB
 
 
 ## All command cheat sheets
-- [`redis`](Docs/docker-commands.md)
+- [`Docker`](Docs/docker-commands.md)
 - [`Postgres`](Docs/postgres.md)
 - [`Alembic`](Docs/alembic.md)
+- [`Redis`](Docs/redis.md)
 
 ## Current Features
 

--- a/app/api/deps/auth.py
+++ b/app/api/deps/auth.py
@@ -1,10 +1,11 @@
 from app.core.settings import settings
 from app.infrastructure.notifications.email_service import DevEmailService, EmailService, SMTPEmailService
 from app.infrastructure.services.otp_ticket_service import OTPTicketService
+from app.infrastructure.security.rate_limiter import RateLimiter
 
 _email_service: EmailService | None = None
 _otp_ticket_service = OTPTicketService()
-
+_rate_limiter = RateLimiter()
 
 def _build_email_service() -> EmailService:
     backend = settings.resolved_email_backend.lower()
@@ -38,3 +39,7 @@ def get_email_service() -> EmailService:
 
 def get_otp_ticket_service() -> OTPTicketService:
     return _otp_ticket_service
+
+
+def get_rate_limiter() -> RateLimiter:
+    return _rate_limiter

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Request
 from starlette.concurrency import run_in_threadpool
 
 from app.api.deps.users import get_create_user_uc
-from app.api.deps.auth import get_email_service, get_otp_ticket_service
+from app.api.deps.auth import get_email_service, get_otp_ticket_service, get_rate_limiter
 from app.application.use_cases.create_user import CreateUser, CreateUserInput, DuplicateEmailError
 from app.infrastructure.notifications.email_service import EmailService
 from app.infrastructure.services.otp_ticket_service import OTPTicketService, OTPInvalidError, TicketInvalidError
@@ -15,10 +15,6 @@ from app.schemas.users import UserResponse
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-# Dependency for RateLimiter (stateless)
-def get_rate_limiter() -> RateLimiter:
-    return RateLimiter()
-
 @router.post("/request-otp", status_code=status.HTTP_204_NO_CONTENT)
 async def request_otp(  
     request: Request,
@@ -27,8 +23,8 @@ async def request_otp(
     email_svc: EmailService = Depends(get_email_service),
     limiter: RateLimiter = Depends(get_rate_limiter),
 ) -> None:
-    # Rate Limit: IP Address
-    # Fallback to 'unknown' if client is None (unlikely in HTTP)
+    # 1. Rate Limiting (IP Based)
+    # Fallback to "unknown" if behind weird proxy, but usually client.host works
     client_ip = request.client.host if request.client else "unknown"
     
     await limiter.allow_request(
@@ -37,7 +33,10 @@ async def request_otp(
         window_seconds=60
     )
 
+    # 2. Issue OTP (Redis)
     result = await otp_svc.issue_otp(payload.email)
+    
+    # 3. Send Email (SMTP or Dev Log)
     await email_svc.send_otp(payload.email, result.otp)
 
 @router.post("/verify-otp", response_model=OTPVerifyResponse)
@@ -46,6 +45,7 @@ async def verify_otp(
     otp_svc: OTPTicketService = Depends(get_otp_ticket_service),
 ) -> OTPVerifyResponse:
     try:
+        # 1. Verify OTP & Issue One-Time Ticket
         ticket = await otp_svc.verify_otp_and_issue_ticket(payload.email, payload.otp)
         return OTPVerifyResponse(signup_ticket=ticket)
     except OTPInvalidError as e:
@@ -58,11 +58,12 @@ async def signup(
     uc: CreateUser = Depends(get_create_user_uc),
 ) -> UserResponse:
     try:
-        # 1) consume ticket first (one-time)
+        # 1. Consume Ticket (Atomic Check-and-Delete)
+        # This prevents Replay Attacks. The ticket is gone after this line.
         await otp_svc.consume_ticket(payload.email, payload.signup_ticket)
 
-        # 2) create user
-        # FIX: Offload sync work to threadpool (Previous Task)
+        # 2. Create User (Non-Blocking)
+        # Offload Sync DB work to threadpool to keep event loop free
         user = await run_in_threadpool(
             uc.execute,
             CreateUserInput(
@@ -72,7 +73,6 @@ async def signup(
             )
         )
 
-        # 3) map to response
         return UserResponse.model_validate(user)
 
     except TicketInvalidError as e:


### PR DESCRIPTION
## Closes :
- #29 

## Summary
This PR implements the production-ready Secure OTP Signup flow. It addresses critical security risks (rate limiting, replay attacks) and performance defects (blocking I/O) identified in the auth architecture.

## Changes
### Features
- **3-Step Flow**: Implemented `request-otp`, `verify-otp`, and `signup` endpoints.
- **Email Backend**: Configured `DevEmailService` (Logs) vs `SMTPEmailService` (SMTP) switching.
- **Replay Protection**: `signup_ticket` is now an opaque Redis key that is atomically deleted upon use.

### Security & Performance
- **Rate Limiting**: Added `RateLimiter` dependency. `request-otp` is limited to 3 req/min/IP.
- **Non-Blocking I/O**: Wrapped synchronous `CreateUser` execution in `run_in_threadpool` to prevent event loop freeze.

## Verification
- **Manual QA**:
  - [x] Rate Limiting triggers 429 after limit exceeded.
  - [x] OTP Verification fails with invalid email/code.
  - [x] Signup flow completes successfully with valid ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with revised cheat sheet links and documentation references.

* **New Features**
  * Added rate limiting protection to OTP authentication requests with per-client IP throttling across a 60-second window to enhance security and prevent abuse.

* **Refactor**
  * Refactored authentication rate limiting as centralized dependency infrastructure for improved modularity and maintainability across all authentication endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->