### PR TITLE
feat: add internal/ops and internal/admin API surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,13 @@ DEBUG=true
 # Run: openssl rand -hex 32
 SECRET_KEY=super-secret-key-that-you-should-change-me
 API_KEY=
+
+# --- Internal surface credentials (hashed) ---
+# echo -n "your-ops-token" | sha256sum
+INTERNAL_OPS_TOKEN_HASH=
+INTERNAL_OPS_TOKEN_ID=ops-shared
+
+# For admin, prefer JWT (set ADMIN_JWT_SECRET) or a shared token hash.
+ADMIN_JWT_SECRET=
+ADMIN_SHARED_TOKEN_HASH=
+ADMIN_TOKEN_ID=admin-shared

--- a/app/api/deps/internal.py
+++ b/app/api/deps/internal.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from app.infrastructure.security.internal_auth import AdminAuthenticator, OpsAuthenticator
+from app.infrastructure.security.rate_limiter import RateLimiter
+from app.infrastructure.logging.audit import AuditLogger
+
+
+# Authentication providers
+@lru_cache(maxsize=1)
+def get_admin_authenticator() -> AdminAuthenticator:
+    return AdminAuthenticator()
+
+
+@lru_cache(maxsize=1)
+def get_ops_authenticator() -> OpsAuthenticator:
+    return OpsAuthenticator()
+
+
+# Rate limiters (shared singleton per process)
+_admin_rate_limiter = RateLimiter()
+_ops_rate_limiter = RateLimiter()
+
+
+def get_admin_rate_limiter() -> RateLimiter:
+    return _admin_rate_limiter
+
+
+def get_ops_rate_limiter() -> RateLimiter:
+    return _ops_rate_limiter
+
+
+@lru_cache(maxsize=1)
+def get_audit_logger() -> AuditLogger:
+    return AuditLogger()
+

--- a/app/api/internal/README.md
+++ b/app/api/internal/README.md
@@ -1,0 +1,18 @@
+# Internal API Surfaces
+
+Two non-public surfaces live under `/api/internal`:
+
+- `internal/ops`: runtime health, safety, abuse signals. Audience: engineers/on-call/automation.
+- `internal/admin`: analytics, KPIs, security views, exports. Audience: privileged human admins/compliance.
+
+Boundary rules (enforced):
+- API handlers stay thin: routing + guards only. No direct DB/Redis/Sentry calls here.
+- Authorization is centralized in `app/api/internal/dependencies.py` using authenticators from `app/infrastructure/security/internal_auth.py`.
+- Rate limiting is centralized via `RateLimiter`; stricter defaults for admin.
+- Admin surface is always authenticated; DEV_AUTH_BYPASS does **not** bypass admin.
+- Audit logging is mandatory for admin; emitted via `AdminAuditMiddleware` to the structured logger in `app/infrastructure/logging/audit.py`. Sensitive headers are redacted.
+
+Adding new endpoints:
+- Put ops routes under `app/api/internal/ops/` and admin routes under `app/api/internal/admin/`.
+- Reuse shared guards via router-level `dependencies=[Depends(admin_guard)]` (admin) or `dependencies=[Depends(_ops_guard)]` (ops).
+- Keep business logic in application layer; import application services instead of hitting infrastructure directly.

--- a/app/api/internal/__init__.py
+++ b/app/api/internal/__init__.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from app.api.internal.ops.router import ops_router
+from app.api.internal.admin.router import admin_router
+
+# Root router for all internal surfaces
+internal_router = APIRouter(prefix="/internal")
+
+# Attach sub-surfaces
+internal_router.include_router(ops_router, prefix="/ops", tags=["internal-ops"])
+internal_router.include_router(admin_router, prefix="/admin", tags=["internal-admin"])
+

--- a/app/api/internal/admin/__init__.py
+++ b/app/api/internal/admin/__init__.py
@@ -1,0 +1,1 @@
+# Namespace package for internal admin surface.

--- a/app/api/internal/admin/business.py
+++ b/app/api/internal/admin/business.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Depends
+
+from app.api.internal.dependencies import admin_guard
+
+router = APIRouter(prefix="/business", dependencies=[Depends(admin_guard)])
+
+
+@router.get("/kpis")
+async def business_kpis() -> dict[str, str]:
+    return {"detail": "business KPIs placeholder"}
+

--- a/app/api/internal/admin/exports.py
+++ b/app/api/internal/admin/exports.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Depends
+
+from app.api.internal.dependencies import admin_guard
+
+router = APIRouter(prefix="/exports", dependencies=[Depends(admin_guard)])
+
+
+@router.get("/preview")
+async def exports_preview() -> dict[str, str]:
+    return {"detail": "exports placeholder"}
+

--- a/app/api/internal/admin/router.py
+++ b/app/api/internal/admin/router.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, Depends
+
+from app.api.internal.admin import system, business, security, exports
+from app.api.internal.dependencies import admin_audit_hook
+
+admin_router = APIRouter(dependencies=[Depends(admin_audit_hook)])
+
+# Attach placeholder modules; they each apply admin guard via shared dependency.
+admin_router.include_router(system.router, tags=["admin-system"])
+admin_router.include_router(business.router, tags=["admin-business"])
+admin_router.include_router(security.router, tags=["admin-security"])
+admin_router.include_router(exports.router, tags=["admin-exports"])
+

--- a/app/api/internal/admin/security.py
+++ b/app/api/internal/admin/security.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Depends
+
+from app.api.internal.dependencies import admin_guard
+
+router = APIRouter(prefix="/security", dependencies=[Depends(admin_guard)])
+
+
+@router.get("/signals")
+async def security_signals() -> dict[str, str]:
+    return {"detail": "admin security signals placeholder"}
+

--- a/app/api/internal/admin/system.py
+++ b/app/api/internal/admin/system.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Depends
+
+from app.api.internal.dependencies import admin_guard
+
+router = APIRouter(prefix="/system", dependencies=[Depends(admin_guard)])
+
+
+@router.get("/overview")
+async def system_overview() -> dict[str, str]:
+    return {"detail": "system overview placeholder"}
+

--- a/app/api/internal/dependencies.py
+++ b/app/api/internal/dependencies.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi import Depends, Request
+
+from app.api.deps.internal import (
+    get_admin_authenticator,
+    get_admin_rate_limiter,
+    get_audit_logger,
+)
+from app.infrastructure.logging.audit import AuditLogger, AuditRecord
+from app.infrastructure.security.internal_auth import AdminAuthenticator
+from app.infrastructure.security.rate_limiter import RateLimiter
+from app.core.settings import settings
+
+
+async def admin_guard(
+    request: Request,
+    authenticator: AdminAuthenticator = Depends(get_admin_authenticator),
+    limiter: RateLimiter = Depends(get_admin_rate_limiter),
+) -> None:
+    identity = authenticator.authenticate(request)
+    request.state.admin_identity = identity
+    client_ip = request.client.host if request.client else "unknown"
+    await limiter.allow_request(
+        key=f"admin:{identity.principal}:{client_ip}",
+        limit=settings.INTERNAL_ADMIN_RATE_LIMIT_PER_MIN,
+        window_seconds=60,
+    )
+
+
+async def admin_audit_hook(
+    request: Request,
+    audit_logger: AuditLogger = Depends(get_audit_logger),
+) -> None:
+    # No-op dependency; middleware handles final emit. Exposes logger so tests can override easily.
+    request.state.audit_logger = audit_logger
+

--- a/app/api/internal/middleware.py
+++ b/app/api/internal/middleware.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Awaitable, Callable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+from app.infrastructure.logging.audit import AuditLogger, AuditRecord
+from app.infrastructure.security.internal_auth import redact_headers
+
+
+class AdminAuditMiddleware(BaseHTTPMiddleware):
+    """Emit audit records for all /internal/admin requests."""
+
+    def __init__(self, app: ASGIApp, audit_logger: AuditLogger | None = None) -> None:
+        super().__init__(app)
+        self._audit_logger = audit_logger or AuditLogger()
+        self._log = logging.getLogger(__name__)
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        path = request.url.path
+        if not path.startswith("/api/internal/admin"):
+            return await call_next(request)
+
+        start = datetime.now(timezone.utc)
+        status_code: int | None = None
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        except Exception as exc:  # noqa: BLE001
+            status_code = getattr(exc, "status_code", None) or 500
+            raise
+        finally:
+            identity = getattr(request.state, "admin_identity", None)
+            logger = getattr(request.state, "audit_logger", self._audit_logger)
+            record = AuditRecord(
+                timestamp=start,
+                principal=identity.principal if identity else "anonymous",
+                auth_type=identity.auth_type if identity else "unknown",
+                endpoint=path,
+                method=request.method,
+                status=status_code or 500,
+                path_params=request.path_params or {},
+                query_params=dict(request.query_params),
+                headers=redact_headers(dict(request.headers)),
+            )
+            try:
+                logger.log(record)
+            except Exception:  # noqa: BLE001
+                self._log.exception("Failed to emit admin audit record")
+

--- a/app/api/internal/ops/__init__.py
+++ b/app/api/internal/ops/__init__.py
@@ -1,0 +1,1 @@
+# Namespace package for internal ops surface.

--- a/app/api/internal/ops/router.py
+++ b/app/api/internal/ops/router.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, Request, Response
+
+from app.api.deps.internal import get_ops_authenticator, get_ops_rate_limiter
+from app.infrastructure.security.internal_auth import OpsAuthenticator
+from app.infrastructure.security.rate_limiter import RateLimiter
+from app.core.settings import settings
+
+ops_router = APIRouter()
+
+
+async def _ops_guard(
+    request: Request,
+    authenticator: OpsAuthenticator = Depends(get_ops_authenticator),
+    limiter: RateLimiter = Depends(get_ops_rate_limiter),
+) -> None:
+    identity = authenticator.authenticate(request)
+    client_ip = request.client.host if request.client else "unknown"
+    await limiter.allow_request(
+        key=f"ops:{identity.principal}:{client_ip}",
+        limit=settings.INTERNAL_OPS_RATE_LIMIT_PER_MIN,
+        window_seconds=60,
+    )
+
+
+@ops_router.get("/health", dependencies=[Depends(_ops_guard)])
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@ops_router.get("/metrics", dependencies=[Depends(_ops_guard)])
+async def metrics() -> dict[str, str]:
+    # Placeholder: real metrics should be provided by dedicated service.
+    return {"detail": "metrics placeholder"}
+
+
+@ops_router.get("/security", dependencies=[Depends(_ops_guard)])
+async def security_signals() -> dict[str, str]:
+    # Placeholder for ops-focused security signals (e.g., abuse indicators).
+    return {"detail": "security signals placeholder"}
+

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.v1 import health, vaults, users, auth, access
+from app.api.internal import internal_router
 from app.websocket import vault_socket
 
 # Root API router
@@ -17,6 +18,9 @@ v1_router.include_router(auth.router)
 v1_router.include_router(access.router)
 # Attach v1 to root
 api_router.include_router(v1_router)
+
+# Internal surfaces (non-public)
+api_router.include_router(internal_router)
 
 # WEBSOCKET (versioned)
 api_router.include_router(vault_socket.router, prefix="/v1", tags=["websockets"])

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -30,6 +30,17 @@ class Settings(BaseSettings):
     # Rate Limiting
     RATE_LIMIT_OTP_REQ_PER_MIN: int = 3
     RATE_LIMIT_LOGIN_REQ_PER_MIN: int = 5
+
+    # Internal surfaces
+    INTERNAL_OPS_TOKEN_HASH: str | None = None
+    INTERNAL_OPS_TOKEN_ID: str | None = None
+    INTERNAL_OPS_RATE_LIMIT_PER_MIN: int = 60
+
+    ADMIN_SHARED_TOKEN_HASH: str | None = None
+    ADMIN_TOKEN_ID: str | None = None
+    ADMIN_JWT_SECRET: str | None = None
+    ADMIN_JWT_ALGORITHM: str = "HS256"
+    INTERNAL_ADMIN_RATE_LIMIT_PER_MIN: int = 20
     
     @property
     def resolved_email_backend(self) -> str:

--- a/app/infrastructure/logging/audit.py
+++ b/app/infrastructure/logging/audit.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any, Dict
+import logging
+
+
+@dataclass
+class AuditRecord:
+    timestamp: datetime
+    principal: str
+    auth_type: str
+    endpoint: str
+    method: str
+    status: int
+    path_params: Dict[str, Any]
+    query_params: Dict[str, Any]
+    headers: Dict[str, str]
+
+
+class AuditLogger:
+    """Lightweight audit logger that emits structured events to standard logging.
+
+    Persistence (DB, SIEM, etc.) can be swapped by replacing this implementation
+    without changing API handlers.
+    """
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or logging.getLogger("audit")
+
+    def log(self, record: AuditRecord) -> None:
+        payload = asdict(record)
+        # Ensure datetime is ISO formatted for downstream processors
+        payload["timestamp"] = record.timestamp.isoformat()
+        self._logger.info("admin_audit", extra={"audit": payload})
+

--- a/app/infrastructure/security/internal_auth.py
+++ b/app/infrastructure/security/internal_auth.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+"""Centralized authentication for internal surfaces.
+
+This module keeps API handlers free of credential handling while allowing
+both shared-token and JWT-based authentication strategies.
+"""
+
+import hashlib
+import hmac
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable
+
+from fastapi import HTTPException, Request, status
+from jose import JWTError, jwt
+
+from app.core.settings import settings
+
+
+SENSITIVE_HEADERS: Iterable[str] = ("authorization", "x-admin-token", "x-ops-token")
+
+
+@dataclass
+class AuthIdentity:
+    principal: str
+    auth_type: str
+    token_id: str | None = None
+    issued_at: datetime | None = None
+
+
+class AuthConfigError(HTTPException):
+    def __init__(self, message: str = "Admin authentication is not configured"):
+        super().__init__(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=message)
+
+
+class ForbiddenError(HTTPException):
+    def __init__(self, message: str = "Insufficient privileges"):
+        super().__init__(status_code=status.HTTP_403_FORBIDDEN, detail=message)
+
+
+class AdminAuthenticator:
+    """Authenticate `internal/admin` requests.
+
+    Supports two strategies:
+    - Bearer JWT with an `admin` role claim
+    - Shared admin token presented via `X-Admin-Token`
+    """
+
+    def __init__(self, cfg=settings):
+        self._cfg = cfg
+
+    def authenticate(self, request: Request) -> AuthIdentity:
+        bearer = request.headers.get("authorization")
+        shared = request.headers.get("x-admin-token")
+
+        if bearer and bearer.lower().startswith("bearer "):
+            token = bearer.split(" ", 1)[1].strip()
+            return self._authenticate_jwt(token)
+
+        if shared:
+            return self._authenticate_shared_token(shared)
+
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Admin credentials required")
+
+    def _authenticate_jwt(self, token: str) -> AuthIdentity:
+        secret = self._cfg.ADMIN_JWT_SECRET or self._cfg.SECRET_KEY
+        if not secret:
+            raise AuthConfigError()
+
+        try:
+            payload = jwt.decode(
+                token,
+                secret,
+                algorithms=[self._cfg.ADMIN_JWT_ALGORITHM],
+                options={"require_exp": False},
+            )
+        except JWTError as exc:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired admin token") from exc
+
+        role = payload.get("role") or payload.get("roles")
+        if isinstance(role, str):
+            has_role = role.lower() == "admin"
+        elif isinstance(role, (list, tuple, set)):
+            has_role = any(str(r).lower() == "admin" for r in role)
+        else:
+            has_role = False
+
+        if not has_role:
+            raise ForbiddenError()
+
+        sub = str(payload.get("sub") or payload.get("admin_id") or "admin")
+        issued_at = payload.get("iat")
+        issued_dt = datetime.fromtimestamp(issued_at, tz=timezone.utc) if isinstance(issued_at, (int, float)) else None
+        return AuthIdentity(
+            principal=sub,
+            auth_type="admin_jwt",
+            token_id=str(payload.get("jti")) if payload.get("jti") else None,
+            issued_at=issued_dt,
+        )
+
+    def _authenticate_shared_token(self, token: str) -> AuthIdentity:
+        expected_hash = self._cfg.ADMIN_SHARED_TOKEN_HASH
+        if not expected_hash:
+            raise AuthConfigError("Shared admin token is not configured")
+
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        if not hmac.compare_digest(digest, expected_hash):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid admin credentials")
+
+        token_id = self._cfg.ADMIN_TOKEN_ID or "admin-shared"
+        return AuthIdentity(principal=token_id, auth_type="shared_token", token_id=token_id)
+
+
+class OpsAuthenticator:
+    """Authenticate `internal/ops` requests.
+
+    By default expects a shared token. In development mode (`DEV_AUTH_BYPASS`),
+    authentication can be skipped to avoid blocking local diagnostics.
+    """
+
+    def __init__(self, cfg=settings):
+        self._cfg = cfg
+
+    def authenticate(self, request: Request) -> AuthIdentity:
+        if self._cfg.DEV_AUTH_BYPASS and not self._cfg.INTERNAL_OPS_TOKEN_HASH:
+            return AuthIdentity(principal="dev-ops", auth_type="dev-bypass")
+
+        expected_hash = self._cfg.INTERNAL_OPS_TOKEN_HASH
+        if not expected_hash:
+            raise AuthConfigError("Ops authentication is not configured")
+
+        token = request.headers.get("x-ops-token")
+        if not token:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Ops credentials required")
+
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        if not hmac.compare_digest(digest, expected_hash):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid ops credentials")
+
+        token_id = self._cfg.INTERNAL_OPS_TOKEN_ID or "ops-shared"
+        return AuthIdentity(principal=token_id, auth_type="shared_token", token_id=token_id)
+
+
+def redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Redact sensitive headers for potential logging."""
+
+    redacted: dict[str, str] = {}
+    for key, value in headers.items():
+        if key.lower() in SENSITIVE_HEADERS:
+            redacted[key] = "[redacted]"
+        else:
+            redacted[key] = value
+    return redacted
+

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,8 @@ from app.core.settings import settings
 from app.core.logging import setup_logging
 from app.infrastructure.messaging.websocket_manager import manager
 from app.infrastructure.cache.redis_client import redis_startup, redis_shutdown
+from app.api.internal.middleware import AdminAuditMiddleware
+from app.infrastructure.logging.audit import AuditLogger
 
 
 
@@ -31,6 +33,9 @@ def create_app() -> FastAPI:
         version="1.0.0",
         lifespan=lifespan,
     )
+
+    # Middleware specific to admin surface
+    app.add_middleware(AdminAuditMiddleware, audit_logger=AuditLogger())
 
     app.include_router(api_router, prefix="/api")
     return app

--- a/app/tests/api/test_internal_admin.py
+++ b/app/tests/api/test_internal_admin.py
@@ -1,0 +1,111 @@
+import hashlib
+
+import pytest
+
+from app.api.deps.internal import get_admin_rate_limiter, get_audit_logger
+from app.core.settings import settings
+from app.infrastructure.security.rate_limiter import RateLimitExceeded
+
+
+VALID_ADMIN_TOKEN = "super-secret-admin"
+VALID_ADMIN_HASH = hashlib.sha256(VALID_ADMIN_TOKEN.encode("utf-8")).hexdigest()
+
+
+class _StubRateLimiter:
+    def __init__(self, limit: int):
+        self.limit = limit
+        self.count = 0
+
+    async def allow_request(self, *args, **kwargs):
+        self.count += 1
+        if self.count > self.limit:
+            raise RateLimitExceeded()
+
+
+class _CaptureAuditLogger:
+    def __init__(self):
+        self.records = []
+
+    def log(self, record):
+        self.records.append(record)
+
+
+@pytest.fixture(autouse=True)
+def _configure_admin_tokens():
+    prev_hash = settings.ADMIN_SHARED_TOKEN_HASH
+    prev_secret = settings.ADMIN_JWT_SECRET
+    prev_id = settings.ADMIN_TOKEN_ID
+    settings.ADMIN_SHARED_TOKEN_HASH = VALID_ADMIN_HASH
+    settings.ADMIN_JWT_SECRET = None
+    settings.ADMIN_TOKEN_ID = "admin-shared-test"
+    yield
+    settings.ADMIN_SHARED_TOKEN_HASH = prev_hash
+    settings.ADMIN_JWT_SECRET = prev_secret
+    settings.ADMIN_TOKEN_ID = prev_id
+
+
+@pytest.fixture(autouse=True)
+def _default_admin_rate_limiter(app):
+    limiter = _StubRateLimiter(limit=100)
+    app.dependency_overrides[get_admin_rate_limiter] = lambda: limiter
+    yield limiter
+    app.dependency_overrides.pop(get_admin_rate_limiter, None)
+
+
+@pytest.fixture
+def capture_audit_logger(app):
+    logger = _CaptureAuditLogger()
+    app.dependency_overrides[get_audit_logger] = lambda: logger
+    yield logger
+    app.dependency_overrides.pop(get_audit_logger, None)
+
+
+@pytest.fixture
+def stub_rate_limiter(app):
+    limiter = _StubRateLimiter(limit=1)
+    app.dependency_overrides[get_admin_rate_limiter] = lambda: limiter
+    yield limiter
+    app.dependency_overrides.pop(get_admin_rate_limiter, None)
+
+
+def test_admin_requires_credentials(client):
+    response = client.get("/api/internal/admin/system/overview")
+    assert response.status_code == 401
+
+
+def test_admin_allows_valid_shared_token_and_audits(client, capture_audit_logger):
+    response = client.get(
+        "/api/internal/admin/system/overview?foo=bar",
+        headers={"X-Admin-Token": VALID_ADMIN_TOKEN},
+    )
+    assert response.status_code == 200
+    assert capture_audit_logger.records, "Audit log should be emitted"
+    record = capture_audit_logger.records[-1]
+    assert record.principal == "admin-shared-test"
+    assert record.headers.get("x-admin-token") == "[redacted]"
+    assert record.query_params.get("foo") == "bar"
+
+
+def test_admin_rejects_invalid_token(client, capture_audit_logger):
+    response = client.get(
+        "/api/internal/admin/system/overview",
+        headers={"X-Admin-Token": "wrong-token"},
+    )
+    assert response.status_code == 401
+    assert capture_audit_logger.records, "Audit log should still be emitted on failure"
+    record = capture_audit_logger.records[-1]
+    assert record.principal == "anonymous"
+    assert record.status == 401
+
+
+def test_admin_rate_limiting(client, stub_rate_limiter):
+    ok = client.get(
+        "/api/internal/admin/system/overview",
+        headers={"X-Admin-Token": VALID_ADMIN_TOKEN},
+    )
+    assert ok.status_code == 200
+    limited = client.get(
+        "/api/internal/admin/system/overview",
+        headers={"X-Admin-Token": VALID_ADMIN_TOKEN},
+    )
+    assert limited.status_code == 429


### PR DESCRIPTION
## Summary
This PR introduces two new internal API surfaces for operational and administrative access, protected by dedicated authentication mechanisms and rate limiting.

### Changes

#### New API Surfaces
- **`/internal/ops`** - Operational endpoints for health checks, metrics, and security signals
- **`/internal/admin`** - Administrative endpoints for system overview, business KPIs, security signals, and exports

#### Authentication
- **Ops Surface**: Shared token authentication via `X-Ops-Token` header (SHA256 hashed)
- **Admin Surface**: Dual authentication support:
  - JWT Bearer token with `admin` role validation
  - Shared token via `X-Admin-Token` header

#### Security
- Rate limiting per surface (ops: 60 req/min, admin: 20 req/min)
- Audit logging middleware for all `/internal/admin` requests
- Sensitive header redaction in logs
- Configurable via environment variables

#### Files Added
- `app/api/internal/` - Router structure for both surfaces
- `app/api/deps/internal.py` - Dependency injection providers
- `app/infrastructure/security/internal_auth.py` - Authenticator classes
- `app/infrastructure/logging/audit.py` - Audit logging infrastructure
- `app/tests/api/test_internal_admin.py` - Test coverage

#### Files Modified
- `app/api/router.py` - Internal router registration
- `app/core/settings.py` - Configuration settings
- `app/main.py` - Middleware integration
- `.env.example` - Documentation of required credentials

### Configuration Required
Set the following environment variables:
- `INTERNAL_OPS_TOKEN_HASH` - SHA256 hash of ops shared token
- `ADMIN_JWT_SECRET` or `ADMIN_SHARED_TOKEN_HASH` - Admin authentication

### Testing
All admin endpoints require authentication. Tests validate proper credential handling and rejection of unauthorized requests.