### PR TITLE
feat(monitoring): add Sentry error tracking integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ DEBUG=true
 # Run: openssl rand -hex 32
 SECRET_KEY=super-secret-key-that-you-should-change-me
 API_KEY=
+
+# Get your DSN from https://sentry.io
+SENTRY_DSN=https://your-key@o123456.ingest.sentry.io/7654321
+SENTRY_ENVIRONMENT=production
+SENTRY_TRACES_SAMPLE_RATE=0.1
+SENTRY_PROFILES_SAMPLE_RATE=0.1
+SENTRY_SEND_DEFAULT_PII=false

--- a/app/core/sentry.py
+++ b/app/core/sentry.py
@@ -1,0 +1,132 @@
+"""
+Sentry error tracking initialization.
+
+SECURITY CONSIDERATIONS:
+- Never send PII (passwords, PINs, tokens)
+- Scrub sensitive data before sending
+- Use appropriate sampling rates
+"""
+
+from __future__ import annotations
+
+import sentry_sdk
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+from sentry_sdk.integrations.redis import RedisIntegration
+
+from app.core.settings import settings
+
+
+def init_sentry() -> None:
+    """
+    Initialize Sentry error tracking.
+    
+    Only initializes if SENTRY_DSN is configured.
+    Integrates with FastAPI, SQLAlchemy, and Redis.
+    """
+    if not settings.SENTRY_DSN:
+        # Sentry not configured - skip initialization
+        return
+    
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.SENTRY_ENVIRONMENT,
+        
+        # Performance monitoring
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        profiles_sample_rate=settings.SENTRY_PROFILES_SAMPLE_RATE,
+        
+        # Privacy
+        send_default_pii=settings.SENTRY_SEND_DEFAULT_PII,
+        
+        # Integrations
+        integrations=[
+            FastApiIntegration(transaction_style="endpoint"),
+            SqlalchemyIntegration(),
+            RedisIntegration(),
+        ],
+        
+        # Data scrubbing
+        before_send=scrub_sensitive_data,
+    )
+
+
+def scrub_sensitive_data(event: dict, hint: dict) -> dict | None:
+    """
+    Scrub sensitive data before sending to Sentry.
+    
+    CRITICAL SECURITY FUNCTION:
+    - Remove passwords, PINs, tokens
+    - Redact sensitive headers
+    - Strip sensitive query parameters
+    
+    Args:
+        event: Sentry event dict
+        hint: Additional context
+        
+    Returns:
+        Scrubbed event or None to drop event
+    """
+    # Scrub request data
+    if "request" in event:
+        request = event["request"]
+        
+        # Scrub headers
+        if "headers" in request:
+            sensitive_headers = {
+                "authorization",
+                "cookie",
+                "x-api-key",
+                "x-auth-token",
+                "x-admin-token",
+            }
+            request["headers"] = {
+                k: "[REDACTED]" if k.lower() in sensitive_headers else v
+                for k, v in request["headers"].items()
+            }
+        
+        # Scrub query parameters
+        if "query_string" in request:
+            sensitive_params = {"pin", "password", "token", "secret"}
+            query_string = request.get("query_string", "")
+            if isinstance(query_string, str):
+                # Check if any sensitive param in query string
+                if any(param in query_string.lower() for param in sensitive_params):
+                    request["query_string"] = "[REDACTED]"
+        
+        # Scrub POST data
+        if "data" in request and isinstance(request["data"], dict):
+            sensitive_fields = {
+                "pin", 
+                "password", 
+                "old_pin", 
+                "new_pin", 
+                "raw_pin",
+                "token",
+                "access_token",
+                "refresh_token",
+                "secret",
+            }
+            for field in sensitive_fields:
+                if field in request["data"]:
+                    request["data"][field] = "[REDACTED]"
+    
+    # Scrub exception context
+    if "exception" in event:
+        for exception in event["exception"].get("values", []):
+            # Remove sensitive data from exception messages
+            if "value" in exception:
+                msg = str(exception["value"]).lower()
+                # Redact if message contains sensitive keywords
+                sensitive_keywords = ["pin", "password", "token", "secret"]
+                if any(keyword in msg for keyword in sensitive_keywords):
+                    exception["value"] = "[Message contains sensitive data - redacted]"
+    
+    # Scrub extra context
+    if "extra" in event:
+        sensitive_keys = {"pin", "password", "token", "secret", "api_key"}
+        for key in list(event["extra"].keys()):
+            if key.lower() in sensitive_keys:
+                event["extra"][key] = "[REDACTED]"
+    
+    return event

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -30,6 +31,32 @@ class Settings(BaseSettings):
     # Rate Limiting
     RATE_LIMIT_OTP_REQ_PER_MIN: int = 3
     RATE_LIMIT_LOGIN_REQ_PER_MIN: int = 5
+    
+    # SENTRY ERROR TRACKING
+    SENTRY_DSN: str | None = Field(
+        None,
+        description="Sentry DSN for error tracking"
+    )
+    SENTRY_ENVIRONMENT: str = Field(
+        "development",
+        description="Environment name (development/staging/production)"
+    )
+    SENTRY_TRACES_SAMPLE_RATE: float = Field(
+        0.1,
+        ge=0.0,
+        le=1.0,
+        description="Percentage of transactions to trace (0.0-1.0)"
+    )
+    SENTRY_PROFILES_SAMPLE_RATE: float = Field(
+        0.1,
+        ge=0.0,
+        le=1.0,
+        description="Percentage of transactions to profile (0.0-1.0)"
+    )
+    SENTRY_SEND_DEFAULT_PII: bool = Field(
+        False,
+        description="Whether to send personally identifiable information (KEEP FALSE)"
+    )
     
     @property
     def resolved_email_backend(self) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -4,10 +4,11 @@ from fastapi import FastAPI
 from app.api.router import api_router
 from app.core.settings import settings
 from app.core.logging import setup_logging
+from app.core.sentry import init_sentry
 from app.infrastructure.messaging.websocket_manager import manager
 from app.infrastructure.cache.redis_client import redis_startup, redis_shutdown
 
-
+init_sentry()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -19,6 +19,9 @@ from app.domain.models.user import User
 from app.tests.fakes.email_service import CaptureEmailService
 from app.infrastructure.cache.redis_client import redis_shutdown
 
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field
+
 
 @pytest.fixture
 def app():
@@ -40,6 +43,47 @@ def app():
         app.dependency_overrides.pop(auth_get_current_user_id, None)
         settings.DEV_AUTH_BYPASS = previous
         settings.REDIS_URL = previous_redis_url
+
+
+@pytest.fixture
+def clean_settings_class(request):
+    """
+    Create a Settings class that doesn't load from .env file or environment.
+    
+    Used for testing default values without environment interference.
+    
+    Clean Architecture Note:
+    - Reuses production Settings class structure (inherits from ProductionSettings)
+    - Only overrides configuration behavior for tests
+    - Uses pytest fixture finalizer to isolate from environment variables
+    - Auto-syncs when production Settings changes
+    """
+    import os
+    
+    # Clean Architecture: Isolate test environment by removing Sentry env vars
+    # This ensures tests run with default values, not CI/production values
+    _sentry_vars = {}
+    for key in list(os.environ.keys()):
+        if key.startswith("SENTRY_"):
+            _sentry_vars[key] = os.environ.pop(key)
+    
+    # Restore after test using pytest's request.finalizer
+    def _restore_sentry():
+        for key, value in _sentry_vars.items():
+            os.environ[key] = value
+    
+    request.addfinalizer(_restore_sentry)
+    
+    from app.core.settings import Settings as ProductionSettings
+    
+    class TestSettings(ProductionSettings):
+        """Test version of Settings that ignores external config."""
+        model_config = SettingsConfigDict(
+            env_file=None,  # Don't load .env
+            extra='ignore'
+        )
+    
+    return TestSettings
 
 
 def _detect_redis_host() -> str:

--- a/app/tests/core/test_sentry_integration.py
+++ b/app/tests/core/test_sentry_integration.py
@@ -1,0 +1,87 @@
+"""Integration tests for Sentry initialization."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.core.sentry import init_sentry
+from app.core.settings import settings
+
+
+def test_sentry_not_initialized_without_dsn():
+    """Sentry is not initialized when DSN is not configured."""
+    with patch('app.core.sentry.sentry_sdk.init') as mock_init:
+        with patch.object(settings, 'SENTRY_DSN', None):
+            init_sentry()
+            
+            # Should NOT call sentry_sdk.init
+            mock_init.assert_not_called()
+
+
+def test_sentry_initialized_with_dsn():
+    """Sentry is initialized when DSN is configured."""
+    test_dsn = "https://test@o123.ingest.sentry.io/456"
+    
+    with patch('app.core.sentry.sentry_sdk.init') as mock_init:
+        with patch.object(settings, 'SENTRY_DSN', test_dsn):
+            with patch.object(settings, 'SENTRY_ENVIRONMENT', 'test'):
+                init_sentry()
+                
+                # Should call sentry_sdk.init
+                mock_init.assert_called_once()
+                
+                # Verify DSN was passed
+                call_kwargs = mock_init.call_args.kwargs
+                assert call_kwargs['dsn'] == test_dsn
+                assert call_kwargs['environment'] == 'test'
+
+
+def test_sentry_integrations_configured():
+    """Sentry integrations are properly configured."""
+    test_dsn = "https://test@o123.ingest.sentry.io/456"
+    
+    with patch('app.core.sentry.sentry_sdk.init') as mock_init:
+        with patch.object(settings, 'SENTRY_DSN', test_dsn):
+            init_sentry()
+            
+            call_kwargs = mock_init.call_args.kwargs
+            integrations = call_kwargs['integrations']
+            
+            # Should have 3 integrations
+            assert len(integrations) == 3
+            
+            # Check integration types
+            integration_names = [type(i).__name__ for i in integrations]
+            assert 'FastApiIntegration' in integration_names
+            assert 'SqlalchemyIntegration' in integration_names
+            assert 'RedisIntegration' in integration_names
+
+
+def test_sentry_before_send_configured():
+    """Sentry before_send hook is configured."""
+    test_dsn = "https://test@o123.ingest.sentry.io/456"
+    
+    with patch('app.core.sentry.sentry_sdk.init') as mock_init:
+        with patch.object(settings, 'SENTRY_DSN', test_dsn):
+            init_sentry()
+            
+            call_kwargs = mock_init.call_args.kwargs
+            
+            # Should have before_send callback
+            assert 'before_send' in call_kwargs
+            assert callable(call_kwargs['before_send'])
+
+
+def test_init_sentry_can_be_called_multiple_times():
+    """init_sentry() can be called multiple times safely."""
+    test_dsn = "https://test@o123.ingest.sentry.io/456"
+    
+    with patch('app.core.sentry.sentry_sdk.init') as mock_init:
+        with patch.object(settings, 'SENTRY_DSN', test_dsn):
+            # Call multiple times
+            init_sentry()
+            init_sentry()
+            init_sentry()
+            
+            # Should only initialize once
+            # (This is Sentry's behavior - calling init() multiple times is safe)
+            assert mock_init.call_count == 3  # Each call goes through

--- a/app/tests/core/test_sentry_scrubbing.py
+++ b/app/tests/core/test_sentry_scrubbing.py
@@ -1,0 +1,238 @@
+"""Tests for Sentry data scrubbing (SECURITY CRITICAL)."""
+
+import pytest
+
+from app.core.sentry import scrub_sensitive_data
+
+
+def test_scrub_authorization_header():
+    """Authorization header is redacted."""
+    event = {
+        "request": {
+            "headers": {
+                "Authorization": "Bearer secret-token-12345",
+                "Content-Type": "application/json",
+            }
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["request"]["headers"]["Authorization"] == "[REDACTED]"
+    assert scrubbed["request"]["headers"]["Content-Type"] == "application/json"
+
+
+def test_scrub_cookie_header():
+    """Cookie header is redacted."""
+    event = {
+        "request": {
+            "headers": {
+                "Cookie": "session=abc123; user=john",
+                "User-Agent": "Mozilla/5.0",
+            }
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["request"]["headers"]["Cookie"] == "[REDACTED]"
+    assert scrubbed["request"]["headers"]["User-Agent"] == "Mozilla/5.0"
+
+
+def test_scrub_admin_token_header():
+    """X-Admin-Token header is redacted."""
+    event = {
+        "request": {
+            "headers": {
+                "X-Admin-Token": "admin-secret-token",
+                "Accept": "application/json",
+            }
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["request"]["headers"]["X-Admin-Token"] == "[REDACTED]"
+
+
+def test_scrub_pin_in_post_data():
+    """PIN in POST data is redacted."""
+    event = {
+        "request": {
+            "data": {
+                "pin": "123456",
+                "vault_id": "vault-123",
+            }
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["request"]["data"]["pin"] == "[REDACTED]"
+    assert scrubbed["request"]["data"]["vault_id"] == "vault-123"
+
+
+def test_scrub_password_in_post_data():
+    """Password in POST data is redacted."""
+    event = {
+        "request": {
+            "data": {
+                "email": "user@example.com",
+                "password": "super-secret-password",
+            }
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["request"]["data"]["password"] == "[REDACTED]"
+    assert scrubbed["request"]["data"]["email"] == "user@example.com"
+
+
+def test_scrub_raw_pin_in_post_data():
+    """raw_pin field is redacted."""
+    event = {
+        "request": {
+            "data": {
+                "vault_id": "vault-123",
+                "raw_pin": "654321",
+            }
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["request"]["data"]["raw_pin"] == "[REDACTED]"
+
+
+def test_scrub_token_in_post_data():
+    """Token fields are redacted."""
+    event = {
+        "request": {
+            "data": {
+                "user_id": "user-123",
+                "token": "jwt-token-abc",
+                "access_token": "access-xyz",
+                "refresh_token": "refresh-123",
+            }
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["request"]["data"]["token"] == "[REDACTED]"
+    assert scrubbed["request"]["data"]["access_token"] == "[REDACTED]"
+    assert scrubbed["request"]["data"]["refresh_token"] == "[REDACTED]"
+    assert scrubbed["request"]["data"]["user_id"] == "user-123"
+
+
+def test_scrub_sensitive_exception_message():
+    """Exception messages containing sensitive data are redacted."""
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ValueError",
+                    "value": "Invalid PIN: 123456 for vault xyz",
+                }
+            ]
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert "123456" not in scrubbed["exception"]["values"][0]["value"]
+    assert "[Message contains sensitive data - redacted]" in scrubbed["exception"]["values"][0]["value"]
+
+
+def test_scrub_password_in_exception():
+    """Exception with password in message is redacted."""
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "AuthError",
+                    "value": "Password verification failed for user",
+                }
+            ]
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["exception"]["values"][0]["value"] == "[Message contains sensitive data - redacted]"
+
+
+def test_scrub_query_string_with_token():
+    """Query strings with tokens are redacted."""
+    event = {
+        "request": {
+            "query_string": "vault_id=123&token=secret-token"
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["request"]["query_string"] == "[REDACTED]"
+
+
+def test_scrub_extra_context():
+    """Extra context with sensitive keys is redacted."""
+    event = {
+        "extra": {
+            "user_id": "user-123",
+            "pin": "123456",
+            "password": "secret",
+            "metadata": {"safe": "data"},
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["extra"]["pin"] == "[REDACTED]"
+    assert scrubbed["extra"]["password"] == "[REDACTED]"
+    assert scrubbed["extra"]["user_id"] == "user-123"
+    assert scrubbed["extra"]["metadata"] == {"safe": "data"}
+
+
+def test_no_scrubbing_for_safe_data():
+    """Safe data is not scrubbed."""
+    event = {
+        "request": {
+            "headers": {
+                "User-Agent": "Mozilla/5.0",
+                "Accept": "application/json",
+            },
+            "data": {
+                "vault_name": "My Vault",
+                "role": "MEMBER",
+            }
+        }
+    }
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed["request"]["headers"]["User-Agent"] == "Mozilla/5.0"
+    assert scrubbed["request"]["data"]["vault_name"] == "My Vault"
+    assert scrubbed["request"]["data"]["role"] == "MEMBER"
+
+
+def test_scrubbing_handles_missing_fields():
+    """Scrubbing doesn't crash on missing fields."""
+    event = {
+        "request": {}
+    }
+    
+    # Should not raise
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed is not None
+
+
+def test_scrubbing_handles_empty_event():
+    """Scrubbing handles completely empty event."""
+    event = {}
+    
+    scrubbed = scrub_sensitive_data(event, {})
+    
+    assert scrubbed == {}

--- a/app/tests/core/test_sentry_settings.py
+++ b/app/tests/core/test_sentry_settings.py
@@ -1,0 +1,88 @@
+"""Tests for Sentry settings configuration."""
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_sentry_dsn_optional(clean_settings_class):
+    """Sentry DSN is optional (for local dev)."""
+    Settings = clean_settings_class
+    
+    settings = Settings(
+        SECRET_KEY="test-key-min-32-chars-long-12345",
+        DATABASE_URL="postgresql://test",
+        REDIS_URL="redis://test",
+        # No SENTRY_DSN
+    )
+    assert settings.SENTRY_DSN is None
+
+
+def test_sentry_environment_defaults_to_development(clean_settings_class):
+    """Environment defaults to development."""
+    Settings = clean_settings_class
+    
+    settings = Settings(
+        SECRET_KEY="test-key-min-32-chars-long-12345",
+        DATABASE_URL="postgresql://test",
+        REDIS_URL="redis://test",
+    )
+    assert settings.SENTRY_ENVIRONMENT == "development"
+
+
+def test_sentry_sample_rates_bounded(clean_settings_class):
+    """Sample rates must be between 0.0 and 1.0."""
+    Settings = clean_settings_class
+    
+    # Valid
+    settings = Settings(
+        SECRET_KEY="test-key-min-32-chars-long-12345",
+        DATABASE_URL="postgresql://test",
+        REDIS_URL="redis://test",
+        SENTRY_TRACES_SAMPLE_RATE=0.5,
+        SENTRY_PROFILES_SAMPLE_RATE=0.1,
+    )
+    assert settings.SENTRY_TRACES_SAMPLE_RATE == 0.5
+    
+    # Invalid (too high)
+    with pytest.raises(ValidationError):
+        Settings(
+            SECRET_KEY="test-key-min-32-chars-long-12345",
+            DATABASE_URL="postgresql://test",
+            REDIS_URL="redis://test",
+            SENTRY_TRACES_SAMPLE_RATE=1.5,
+        )
+    
+    # Invalid (negative)
+    with pytest.raises(ValidationError):
+        Settings(
+            SECRET_KEY="test-key-min-32-chars-long-12345",
+            DATABASE_URL="postgresql://test",
+            REDIS_URL="redis://test",
+            SENTRY_PROFILES_SAMPLE_RATE=-0.1,
+        )
+
+
+def test_sentry_pii_defaults_to_false(clean_settings_class):
+    """PII sending is disabled by default (security)."""
+    Settings = clean_settings_class
+    
+    settings = Settings(
+        SECRET_KEY="test-key-min-32-chars-long-12345",
+        DATABASE_URL="postgresql://test",
+        REDIS_URL="redis://test",
+    )
+    assert settings.SENTRY_SEND_DEFAULT_PII is False
+
+
+def test_sentry_dsn_can_be_set(clean_settings_class):
+    """Sentry DSN can be configured."""
+    Settings = clean_settings_class
+    
+    test_dsn = "https://test@o123.ingest.sentry.io/456"
+    settings = Settings(
+        SECRET_KEY="test-key-min-32-chars-long-12345",
+        DATABASE_URL="postgresql://test",
+        REDIS_URL="redis://test",
+        SENTRY_DSN=test_dsn,
+    )
+    assert settings.SENTRY_DSN == test_dsn

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pydantic[email]
 redis>=5
 aiosmtplib
 pytest-asyncio
+sentry-sdk[fastapi]==1.40.0


### PR DESCRIPTION
## Summary

This PR integrates Sentry for error tracking and performance monitoring in the Smart Vault API. It adds centralized configuration, proper SDK initialization, and test isolation to ensure reliable monitoring without affecting test reliability.

### Changes

#### Configuration (`app/core/settings.py`)
- Added Sentry settings with sensible defaults:
  - `SENTRY_DSN` - Optional DSN for error tracking
  - `SENTRY_ENVIRONMENT` - Defaults to "development"
  - `SENTRY_TRACES_SAMPLE_RATE` - 10% tracing (0.1)
  - `SENTRY_PROFILES_SAMPLE_RATE` - 10% profiling (0.1)
  - `SENTRY_SEND_DEFAULT_PII` - Disabled by default (security)

#### Sentry Initialization (`app/core/sentry.py`)
- Created dedicated module for Sentry SDK initialization
- Properly configured FastAPI integration
- Added PII scrubbing for sensitive data

#### Application Integration (`app/main.py`)
- Initialize Sentry at application startup before any routes are registered
- Ensures all errors are captured from the start

#### Test Isolation (`app/tests/conftest.py`)
- Added `clean_settings_class` fixture that:
  - Removes Sentry environment variables before tests
  - Restores environment after tests complete
  - Inherits from `ProductionSettings` following Clean Architecture
  - Prevents CI/production Sentry credentials from affecting test defaults

#### Dependencies (`requirements.txt`)
- Added `sentry-sdk[fastapi]==1.40.0`

#### Documentation (`.env.example`)
- Added Sentry configuration section with example values
- Documented required environment variable setup

### Clean Architecture Principles Applied
- **Dependency Inversion**: Sentry initialization abstracted in `app/core/sentry.py`
- **Single Responsibility**: Each module has one clear purpose
- **Explicit Dependencies**: Configuration clearly documented and typed
- **Test Isolation**: Fixture ensures tests run with controlled defaults

### Configuration Required
To enable Sentry, set these environment variables:
```bash
SENTRY_DSN=https://your-key@o123456.ingest.sentry.io/7654321
SENTRY_ENVIRONMENT=production  # or development
