### PR TITLE
debug: temporary print response payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     services:
+      postgres:
+        image: postgres:15
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: smartvault
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd "pg_isready -U postgres -d smartvault"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+
       redis:
         image: redis:7
         ports:
@@ -25,8 +39,14 @@ jobs:
           --health-retries 20
 
     env:
+      # CI runs on host network; use localhost + published ports
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/smartvault
       REDIS_URL: redis://localhost:6379/0
+
+      # required by Settings/tests
       SECRET_KEY: super-secret-key-that-you-should-change-me
+      APP_ENV: development
+      DEBUG: "true"
 
     steps:
       - name: Checkout

--- a/app/tests/api/test_health.py
+++ b/app/tests/api/test_health.py
@@ -20,6 +20,8 @@ def test_health_detailed_all_dependencies_healthy(client, vault_repo):
     assert response.status_code == 200
     data = response.json()
     
+    print("HEALTH_DETAILED_RESPONSE:", data)
+    
     assert data["status"] == "healthy"
     assert len(data["dependencies"]) == 2
     


### PR DESCRIPTION
This pull request updates the CI workflow to add a PostgreSQL service for testing, configures related environment variables, and adds a debug print statement in the health check test. The main focus is to ensure the test environment closely matches production requirements and to aid in debugging test failures.

**CI/CD Workflow Improvements:**

* Added a `postgres` service (PostgreSQL 15) to the GitHub Actions workflow, including health checks and environment configuration, to support database-dependent tests.
* Set the `DATABASE_URL` environment variable for tests to connect to the new PostgreSQL service, aligning the test environment with application requirements.
* Added `APP_ENV` and `DEBUG` environment variables to the workflow to further mimic the application's expected runtime environment.

**Testing Improvements:**

* Added a print statement to output the detailed health check response in `test_health_detailed_all_dependencies_healthy` to assist with debugging test runs.