### PR TITLE
feat: Implemented Password Reset Flow

### DIFF
--- a/app/api/deps/auth.py
+++ b/app/api/deps/auth.py
@@ -2,15 +2,19 @@ from app.core.settings import settings
 from redis import Redis
 from app.infrastructure.notifications.email_service import DevEmailService, EmailService, SMTPEmailService
 from app.infrastructure.services.otp_ticket_service import OTPTicketService
+from app.infrastructure.services.password_reset_service import PasswordResetService
 from app.infrastructure.security.rate_limiter import RateLimiter
 from app.application.services.token_service import TokenService
+from app.application.use_cases.reset_password import RequestPasswordReset, ConfirmPasswordReset
 from app.infrastructure.services.refresh_token_store import RedisRefreshTokenStore
+from app.api.deps.users import get_user_repo, get_password_hasher
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import jwt, JWTError
 
 _email_service: EmailService | None = None
 _otp_ticket_service = OTPTicketService()
+_password_reset_service = PasswordResetService()
 _rate_limiter = RateLimiter()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
 
@@ -50,12 +54,29 @@ def get_email_service() -> EmailService:
 def get_otp_ticket_service() -> OTPTicketService:
     return _otp_ticket_service
 
+def get_password_reset_service() -> PasswordResetService:
+    return _password_reset_service
+
 def get_rate_limiter() -> RateLimiter:
     return _rate_limiter
 
 def get_token_service() -> TokenService:
     store = get_refresh_token_store()
     return TokenService(store)
+
+def get_request_password_reset_uc(
+    repo=Depends(get_user_repo),
+    reset_svc=Depends(get_password_reset_service),
+    email_svc=Depends(get_email_service),
+) -> RequestPasswordReset:
+    return RequestPasswordReset(repo, reset_svc, email_svc)
+
+def get_confirm_password_reset_uc(
+    repo=Depends(get_user_repo),
+    reset_svc=Depends(get_password_reset_service),
+    hasher=Depends(get_password_hasher),
+) -> ConfirmPasswordReset:
+    return ConfirmPasswordReset(repo, reset_svc, hasher)
 
 def get_current_user_id(token: str = Depends(oauth2_scheme)) -> str:
     # 1. Test Bypass (Critical for acceptance criteria)

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -4,9 +4,13 @@ from fastapi import APIRouter, Depends, HTTPException, status, Request
 from starlette.concurrency import run_in_threadpool
 
 from app.api.deps.users import get_create_user_uc, get_authenticate_user_uc
-from app.api.deps.auth import get_email_service, get_otp_ticket_service, get_rate_limiter, get_token_service
+from app.api.deps.auth import (
+    get_email_service, get_otp_ticket_service, get_rate_limiter, get_token_service,
+    get_request_password_reset_uc, get_confirm_password_reset_uc
+)
 from app.application.use_cases.create_user import CreateUser, CreateUserInput, DuplicateEmailError
 from app.application.use_cases.authenticate_user import AuthenticateUser, LoginInput, InvalidCredentialsError
+from app.application.use_cases.reset_password import RequestPasswordReset, RequestPasswordResetInput, ConfirmPasswordReset, ConfirmPasswordResetInput
 from app.application.services.token_service import TokenService
 from app.infrastructure.notifications.email_service import EmailService
 from app.infrastructure.services.otp_ticket_service import OTPTicketService, OTPInvalidError, TicketInvalidError
@@ -15,7 +19,8 @@ from app.core.settings import settings
 # Updated imports
 from app.schemas.auth import (
     OTPRequest, OTPVerifyRequest, OTPVerifyResponse, SignupRequest, 
-    LoginRequest, Token, RefreshRequest, LogoutRequest
+    LoginRequest, Token, RefreshRequest, LogoutRequest,
+    PasswordResetRequest, PasswordResetConfirm
 )
 from app.schemas.users import UserResponse
 
@@ -142,3 +147,26 @@ async def logout(
     token_svc: TokenService = Depends(get_token_service),
 ) -> None:
     token_svc.revoke_refresh_token(payload.refresh_token)
+
+# NEW: REQUEST PASSWORD RESET ENDPOINT
+@router.post("/request-password-reset", status_code=status.HTTP_204_NO_CONTENT)
+async def request_password_reset(
+    payload: PasswordResetRequest,
+    uc: RequestPasswordReset = Depends(get_request_password_reset_uc),
+) -> None:
+    await uc.execute(RequestPasswordResetInput(email=payload.email))
+
+
+# NEW: CONFIRM PASSWORD RESET ENDPOINT
+@router.post("/confirm-password-reset", status_code=status.HTTP_204_NO_CONTENT)
+async def confirm_password_reset(
+    payload: PasswordResetConfirm,
+    uc: ConfirmPasswordReset = Depends(get_confirm_password_reset_uc),
+) -> None:
+    try:
+        await uc.execute(ConfirmPasswordResetInput(
+            token=payload.token,
+            new_password=payload.new_password,
+        ))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))

--- a/app/application/ports/user_repository.py
+++ b/app/application/ports/user_repository.py
@@ -27,3 +27,7 @@ class UserRepository(ABC):
     @abstractmethod
     def update_profile(self, user_id: str, full_name: str | None) -> User | None:
         raise NotImplementedError
+
+    @abstractmethod
+    def update_password(self, user_id: str, password_hash: str) -> User | None:
+        raise NotImplementedError

--- a/app/application/use_cases/reset_password.py
+++ b/app/application/use_cases/reset_password.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.application.ports.user_repository import UserRepository
+from app.infrastructure.services.password_reset_service import PasswordResetService
+from app.infrastructure.notifications.email_service import EmailService
+
+
+class PasswordHasher(Protocol):
+    def hash(self, raw_password: str) -> str:
+        ...
+
+
+@dataclass(frozen=True)
+class RequestPasswordResetInput:
+    email: str
+
+
+class RequestPasswordReset:
+    def __init__(
+        self,
+        repo: UserRepository,
+        reset_svc: PasswordResetService,
+        email_svc: EmailService,
+    ):
+        self._repo = repo
+        self._reset_svc = reset_svc
+        self._email_svc = email_svc
+
+    async def execute(self, inp: RequestPasswordResetInput) -> None:
+        email = inp.email.strip().lower()
+        user = self._repo.get_by_email(email)
+        
+        # Always return success to avoid email enumeration
+        if user is None:
+            return
+
+        token = await self._reset_svc.issue_token(email)
+        await self._email_svc.send_password_reset_token(email, token)
+
+
+@dataclass(frozen=True)
+class ConfirmPasswordResetInput:
+    token: str
+    new_password: str
+
+
+class ConfirmPasswordReset:
+    def __init__(
+        self,
+        repo: UserRepository,
+        reset_svc: PasswordResetService,
+        hasher: PasswordHasher,
+    ):
+        self._repo = repo
+        self._reset_svc = reset_svc
+        self._hasher = hasher
+
+    async def execute(self, inp: ConfirmPasswordResetInput) -> None:
+        email = await self._reset_svc.consume_token(inp.token)
+        if email is None:
+            raise ValueError("Invalid or expired reset token")
+
+        user = self._repo.get_by_email(email)
+        if user is None:
+            # Should not happen if token was issued for this email, but be safe
+            raise ValueError("User no longer exists")
+
+        if len(inp.new_password) < 12:
+            raise ValueError("Password must be at least 12 characters")
+
+        password_hash = self._hasher.hash(inp.new_password)
+        self._repo.update_password(user.id, password_hash)

--- a/app/application/use_cases/reset_password.py
+++ b/app/application/use_cases/reset_password.py
@@ -59,6 +59,9 @@ class ConfirmPasswordReset:
         self._hasher = hasher
 
     async def execute(self, inp: ConfirmPasswordResetInput) -> None:
+        if len(inp.new_password) < 12:
+            raise ValueError("Password must be at least 12 characters")
+
         email = await self._reset_svc.consume_token(inp.token)
         if email is None:
             raise ValueError("Invalid or expired reset token")
@@ -68,8 +71,7 @@ class ConfirmPasswordReset:
             # Should not happen if token was issued for this email, but be safe
             raise ValueError("User no longer exists")
 
-        if len(inp.new_password) < 12:
-            raise ValueError("Password must be at least 12 characters")
-
         password_hash = self._hasher.hash(inp.new_password)
-        self._repo.update_password(user.id, password_hash)
+        updated = self._repo.update_password(user.id, password_hash)
+        if updated is None:
+            raise ValueError("Failed to update password")

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     # OTP + ticket
     OTP_TTL_SECONDS: int = 600          # 10 min
     SIGNUP_TICKET_TTL_SECONDS: int = 300 # 5 min
+    PASSWORD_RESET_TTL_SECONDS: int = 900 # 15 min
     
     # Rate Limiting
     RATE_LIMIT_OTP_REQ_PER_MIN: int = 3

--- a/app/infrastructure/db/repositories/in_memory_user_repository.py
+++ b/app/infrastructure/db/repositories/in_memory_user_repository.py
@@ -43,5 +43,14 @@ class InMemoryUserRepository(UserRepository):
         self.save(updated_user)
         return updated_user
 
+    def update_password(self, user_id: str, password_hash: str) -> User | None:
+        user = self.get_by_id(user_id)
+        if not user:
+            return None
+        
+        updated_user = replace(user, password_hash=password_hash)
+        self.save(updated_user)
+        return updated_user
+
     def get_by_ids(self, user_ids: list[str]) -> dict[str, User]:
         return {uid: user for uid, user in self._by_id.items() if uid in user_ids}

--- a/app/infrastructure/db/repositories/sqlalchemy_user_repository.py
+++ b/app/infrastructure/db/repositories/sqlalchemy_user_repository.py
@@ -84,3 +84,15 @@ class SqlAlchemyUserRepository(UserRepository):
         updated_orm = result.scalar_one_or_none()
         self._db.flush()                # FIXED: uses self._db
         return self._to_domain(updated_orm) if updated_orm else None
+
+    def update_password(self, user_id: str, password_hash: str) -> User | None:
+        stmt = (
+            update(UserORM)
+            .where(UserORM.id == user_id)
+            .values(password_hash=password_hash)
+            .returning(UserORM)
+        )
+        result = self._db.execute(stmt)
+        updated_orm = result.scalar_one_or_none()
+        self._db.flush()
+        return self._to_domain(updated_orm) if updated_orm else None

--- a/app/infrastructure/notifications/email_service.py
+++ b/app/infrastructure/notifications/email_service.py
@@ -18,12 +18,20 @@ class EmailService(Protocol):
     async def send_otp(self, to_email: str, otp: str) -> None:
         ...
 
+    async def send_password_reset_token(self, to_email: str, token: str) -> None:
+        ...
+
 
 class DevEmailService:
     async def send_otp(self, to_email: str, otp: str) -> None:
         # Dev-only backend; mask OTP and log at debug level only.
         masked = otp[:2] + "*" * max(0, len(otp) - 2)
         log.debug("DEV EMAIL: sending masked OTP to %s code=%s", to_email, masked)
+
+    async def send_password_reset_token(self, to_email: str, token: str) -> None:
+        # Dev-only backend; mask token and log at debug level only.
+        masked = token[:4] + "..." + token[-4:]
+        log.debug("DEV EMAIL: sending masked reset token to %s token=%s", to_email, masked)
 
 
 class SMTPEmailService:
@@ -63,6 +71,34 @@ class SMTPEmailService:
             "Use the code below to finish signing in to SmartVault.\n\n"
             f"Code: {otp}\n"
             "If you did not request this code, you can ignore this email."
+        )
+
+        await aiosmtplib.send(
+            message=msg,
+            hostname=self.host,
+            port=self.port,
+            username=self.username,
+            password=self.password,
+            start_tls=self.use_tls,
+        )
+
+    async def send_password_reset_token(self, to_email: str, token: str) -> None:
+        assert aiosmtplib is not None, "SMTP backend not available"
+
+        msg = EmailMessage()
+        msg["From"] = (
+            formataddr((self.from_name, self.from_email))
+            if self.from_name
+            else self.from_email
+        )
+        msg["To"] = to_email
+        msg["Subject"] = "Password reset for SmartVault"
+        msg.set_content(
+            "We received a request to reset your SmartVault password.\n"
+            "Use the token below to set a new password:\n\n"
+            f"Token: {token}\n\n"
+            "This token will expire in 15 minutes.\n"
+            "If you did not request a password reset, you can ignore this email."
         )
 
         await aiosmtplib.send(

--- a/app/infrastructure/services/password_reset_service.py
+++ b/app/infrastructure/services/password_reset_service.py
@@ -49,9 +49,15 @@ return current
                 return result.decode("utf-8")
             return result
         except ResponseError:
-            # Fallback if EVAL is disabled: best-effort match then delete
-            value = await redis.get(key)
+            # Fallback if EVAL is disabled: use GETDEL for atomicity
+            try:
+                value = await redis.getdel(key)
+            except (ResponseError, AttributeError):
+                # Redis < 6.2 or older redis-py: best-effort GET+DEL (not atomic)
+                value = await redis.get(key)
+                if value is not None:
+                    await redis.delete(key)
+            
             if value is None:
                 return None
-            await redis.delete(key)
             return value.decode("utf-8")

--- a/app/infrastructure/services/password_reset_service.py
+++ b/app/infrastructure/services/password_reset_service.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import secrets
+from redis.exceptions import ResponseError
+
+from app.core.settings import settings
+from app.infrastructure.cache.redis_client import (
+    get_redis,
+    redis_setex,
+)
+
+class PasswordResetService:
+    _CONSUME_LUA = """
+local current = redis.call('GET', KEYS[1])
+if not current then return nil end
+-- prefer GETDEL when available (Redis >= 6.2)
+local ok, val = pcall(redis.call, 'GETDEL', KEYS[1])
+if ok then
+  return val
+end
+redis.call('DEL', KEYS[1])
+return current
+"""
+
+    def _token_key(self, token: str) -> str:
+        return f"pwd_reset:{token}"
+
+    async def issue_token(self, email: str) -> str:
+        token = secrets.token_urlsafe(32)
+        await redis_setex(
+            self._token_key(token),
+            settings.PASSWORD_RESET_TTL_SECONDS,
+            email.lower().encode("utf-8"),
+        )
+        return token
+
+    async def consume_token(self, token: str) -> str | None:
+        """Atomically read-and-delete the reset token.
+
+        Returns:
+            str: the email associated with the token if matched and deleted
+            None: when token is missing/expired
+        """
+        key = self._token_key(token)
+        redis = await get_redis()
+        try:
+            result = await redis.eval(self._CONSUME_LUA, 1, key)
+            if isinstance(result, bytes):
+                return result.decode("utf-8")
+            return result
+        except ResponseError:
+            # Fallback if EVAL is disabled: best-effort match then delete
+            value = await redis.get(key)
+            if value is None:
+                return None
+            await redis.delete(key)
+            return value.decode("utf-8")

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -32,3 +32,10 @@ class RefreshRequest(BaseModel):
 
 class LogoutRequest(BaseModel):
     refresh_token: str
+
+class PasswordResetRequest(BaseModel):
+    email: EmailStr
+
+class PasswordResetConfirm(BaseModel):
+    token: str = Field(min_length=20)
+    new_password: str = Field(min_length=12, max_length=128)

--- a/app/tests/api/test_auth_password_reset.py
+++ b/app/tests/api/test_auth_password_reset.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone
+from app.domain.models.user import User
+
+def test_password_reset_happy_path(client, capture_email_service, user_repo):
+    email = "reset@example.com"
+    old_password = "oldpassword123!"
+    new_password = "newpassword123!"
+    
+    # Setup: create a user
+    client.post("/api/v1/auth/request-otp", json={"email": email})
+    otp = capture_email_service.latest_otp_for(email)
+    r_verify = client.post("/api/v1/auth/verify-otp", json={"email": email, "otp": otp})
+    ticket = r_verify.json()["signup_ticket"]
+    client.post("/api/v1/auth/signup", json={
+        "email": email,
+        "password": old_password,
+        "signup_ticket": ticket
+    })
+    
+    # 1. Request password reset
+    r1 = client.post("/api/v1/auth/request-password-reset", json={"email": email})
+    assert r1.status_code == 204
+    
+    token = capture_email_service.latest_token_for(email)
+    assert token is not None
+    
+    # 2. Confirm password reset
+    r2 = client.post("/api/v1/auth/confirm-password-reset", json={
+        "token": token,
+        "new_password": new_password
+    })
+    assert r2.status_code == 204
+    
+    # 3. Verify login with new password
+    r3 = client.post("/api/v1/auth/login", json={
+        "email": email,
+        "password": new_password
+    })
+    assert r3.status_code == 200
+    assert "access_token" in r3.json()
+    
+    # 4. Verify old password no longer works
+    r4 = client.post("/api/v1/auth/login", json={
+        "email": email,
+        "password": old_password
+    })
+    assert r4.status_code == 401
+
+def test_password_reset_unknown_email(client, capture_email_service):
+    email = "unknown@example.com"
+    
+    r1 = client.post("/api/v1/auth/request-password-reset", json={"email": email})
+    assert r1.status_code == 204
+    
+    # No email should be sent
+    token = capture_email_service.latest_token_for(email)
+    assert token is None
+
+def test_password_reset_invalid_token(client):
+    r1 = client.post("/api/v1/auth/confirm-password-reset", json={
+        "token": "invalid-token-that-is-long-enough-for-pydantic",
+        "new_password": "newpassword123!"
+    })
+    assert r1.status_code == 422
+    assert "Invalid or expired reset token" in r1.json()["detail"]
+
+def test_password_reset_token_reuse_fails(client, capture_email_service, user_repo):
+    email = "reuse@example.com"
+    password = "password123456"
+    
+    # Setup: create user
+    client.post("/api/v1/auth/request-otp", json={"email": email})
+    otp = capture_email_service.latest_otp_for(email)
+    ticket = client.post("/api/v1/auth/verify-otp", json={"email": email, "otp": otp}).json()["signup_ticket"]
+    client.post("/api/v1/auth/signup", json={"email": email, "password": password, "signup_ticket": ticket})
+    
+    # Request reset
+    client.post("/api/v1/auth/request-password-reset", json={"email": email})
+    token = capture_email_service.latest_token_for(email)
+    
+    # Use token once
+    r1 = client.post("/api/v1/auth/confirm-password-reset", json={
+        "token": token,
+        "new_password": "newpassword123!"
+    })
+    assert r1.status_code == 204
+    
+    # Use token again
+    r2 = client.post("/api/v1/auth/confirm-password-reset", json={
+        "token": token,
+        "new_password": "anotherpassword123!"
+    })
+    assert r2.status_code == 422
+    assert "Invalid or expired reset token" in r2.json()["detail"]
+
+def test_password_reset_password_too_short(client, capture_email_service, user_repo):
+    email = "short@example.com"
+    password = "password123456"
+    
+    # Setup: create user
+    client.post("/api/v1/auth/request-otp", json={"email": email})
+    otp = capture_email_service.latest_otp_for(email)
+    ticket = client.post("/api/v1/auth/verify-otp", json={"email": email, "otp": otp}).json()["signup_ticket"]
+    client.post("/api/v1/auth/signup", json={"email": email, "password": password, "signup_ticket": ticket})
+    
+    # Request reset
+    client.post("/api/v1/auth/request-password-reset", json={"email": email})
+    token = capture_email_service.latest_token_for(email)
+    
+    # Confirm with short password
+    r1 = client.post("/api/v1/auth/confirm-password-reset", json={
+        "token": token,
+        "new_password": "short"
+    })
+    # Pydantic should catch this first if min_length=12
+    assert r1.status_code == 422

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -128,6 +128,14 @@ class _FakeUserRepo(UserRepository):
         self.save(updated)
         return updated
 
+    def update_password(self, user_id: str, password_hash: str):
+        user = self.get_by_id(user_id)
+        if not user:
+            return None
+        updated = replace(user, password_hash=password_hash)
+        self.save(updated)
+        return updated
+
 
 class _NoopRateLimiter:
     async def allow_request(self, *args, **kwargs):

--- a/app/tests/fakes/email_service.py
+++ b/app/tests/fakes/email_service.py
@@ -12,21 +12,38 @@ class SentOTP:
     otp: str
 
 
+@dataclass
+class SentToken:
+    to_email: str
+    token: str
+
+
 class CaptureEmailService(EmailService):
     """
-    Test double that captures OTPs instead of sending real email.
+    Test double that captures OTPs and tokens instead of sending real email.
     """
     def __init__(self) -> None:
         self.sent: list[SentOTP] = []
-        self._latest_by_email: Dict[str, str] = {}
+        self.sent_tokens: list[SentToken] = []
+        self._latest_otp_by_email: Dict[str, str] = {}
+        self._latest_token_by_email: Dict[str, str] = {}
 
     async def send_otp(self, to_email: str, otp: str) -> None:
         self.sent.append(SentOTP(to_email=to_email, otp=otp))
-        self._latest_by_email[to_email] = otp
+        self._latest_otp_by_email[to_email] = otp
+
+    async def send_password_reset_token(self, to_email: str, token: str) -> None:
+        self.sent_tokens.append(SentToken(to_email=to_email, token=token))
+        self._latest_token_by_email[to_email] = token
 
     def latest_otp_for(self, email: str) -> Optional[str]:
-        return self._latest_by_email.get(email)
+        return self._latest_otp_by_email.get(email)
+
+    def latest_token_for(self, email: str) -> Optional[str]:
+        return self._latest_token_by_email.get(email)
 
     def clear(self) -> None:
         self.sent.clear()
-        self._latest_by_email.clear()
+        self.sent_tokens.clear()
+        self._latest_otp_by_email.clear()
+        self._latest_token_by_email.clear()


### PR DESCRIPTION
# Implement Password Reset Flow (Issue #39)

## Overview
This PR implements a secure, end-to-end "Forgot Password" flow. Users can now request a password reset via email and set a new password using a time-limited, one-time-use token.

## Changes
### 🔐 Security & Logic
- **Enumeration Protection:** `POST /request-password-reset` always returns `204 No Content` even if the email doesn't exist, preventing attackers from harvesting valid user emails.
- **One-Time Token:** Reset tokens are consumed atomically (GET + DEL) from Redis using Lua scripts to prevent reuse.
- **TTL Management:** Tokens expire automatically after 15 minutes (configurable via `PASSWORD_RESET_TTL_SECONDS`).
- **Validation:** Enforces a minimum password length of 12 characters and validates token existence before updating the database.

### 🏗 Architecture
- **Domain/Port:** Added `update_password` to `UserRepository`.
- **Infrastructure:**
    - Created `PasswordResetService` to manage Redis-backed tokens.
    - Extended `EmailService` and `SMTPEmailService` to handle reset notifications.
    - Implemented `update_password` in both `SqlAlchemyUserRepository` and `InMemoryUserRepository`.
- **Application:** Created `RequestPasswordReset` and `ConfirmPasswordReset` use cases.
- **API:** Added two new endpoints in `v1/auth.py` with corresponding Pydantic schemas.

### 🧪 Quality Assurance
- Added 5 comprehensive test cases in `app/tests/api/test_auth_password_reset.py`:
    - Happy path (Request -> Reset -> Login).
    - Invalid/Expired token handling (422).
    - Token reuse rejection (422).
    - Unknown email handling (204, no email sent).
    - Input validation (Password complexity/length).

## How to Test
1. **Run automated tests:**
   ```bash
   make test-k k=password_reset
   ```
2. **Manual verification (Dev mode):**
   - Trigger a reset: `POST /api/v1/auth/request-password-reset` with a registered email.
   - Check API logs for the masked token (using `DevEmailService`).
   - Confirm reset: `POST /api/v1/auth/confirm-password-reset` with the token and a new 12+ char password.
   - Verify login with the new password.
---
*Closes #39*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password reset workflow: request reset by email and confirm with a single-use token.
  * Tokens expire (configurable, default 15 minutes) and are single-use; new-password minimum 12 characters.
  * Email delivery for reset tokens supported in dev and SMTP modes; unknown emails handled gracefully.

* **Tests**
  * Added end-to-end tests covering happy path, unknown email, invalid/expired token, token reuse, and password validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->