### PR TITLE
feat(env): change SENTRY_ENVIRONMENT to development for local setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ API_KEY=
 
 # Get your DSN from https://sentry.io
 SENTRY_DSN=https://your-key@o123456.ingest.sentry.io/7654321
-SENTRY_ENVIRONMENT=development  # Default for development; change for staging/production
+SENTRY_ENVIRONMENT=development
 SENTRY_TRACES_SAMPLE_RATE=0.1
 SENTRY_PROFILES_SAMPLE_RATE=0.1
 SENTRY_SEND_DEFAULT_PII=false

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ API_KEY=
 
 # Get your DSN from https://sentry.io
 SENTRY_DSN=https://your-key@o123456.ingest.sentry.io/7654321
-SENTRY_ENVIRONMENT=production
+SENTRY_ENVIRONMENT=development  # Default for development; change for staging/production
 SENTRY_TRACES_SAMPLE_RATE=0.1
 SENTRY_PROFILES_SAMPLE_RATE=0.1
 SENTRY_SEND_DEFAULT_PII=false


### PR DESCRIPTION
Closes: #72 
----

## What's New in This PR

This PR updates the `.env.example` file to set `SENTRY_ENVIRONMENT` to `development` by default, instead of `production`. This provides a safer default for local development environments.

### Quick Setup

**For Backend Developers:**
```bash
# No action required if you already have .env configured
# For new setup or reset:
cp .env.example .env

# Your Sentry events will now be tagged as 'development' by default
# Change to 'staging' or 'production' when deploying
```

**For Frontend Developers:**
Not applicable - backend configuration only.

---

## TL;DR

Changed `SENTRY_ENVIRONMENT` default from `production` to `development` in `.env.example` to prevent local dev errors from being tagged as production incidents.

---

## Summary

The `.env.example` template previously defaulted `SENTRY_ENVIRONMENT=production`, which could lead to confusion when developers copy this file for local development. Local development errors would be incorrectly categorized as production issues in Sentry.

This PR fixes that by:
- Setting the default to `development`
- Adding a helpful comment to remind developers to change it for staging/production deployments
- Maintaining safe defaults for local development workflow

---

## Key Features

✅ **Safer Defaults**: Local development errors are now properly tagged as `development`  
✅ **Better DX**: Developers don't need to manually change this setting for local work  
✅ **Clear Documentation**: Added inline comment to guide deployment configuration  
✅ **Zero Breaking Changes**: Existing `.env` files are unaffected  

---

## Technical Changes

### Modified Files
- `.env.example` - Updated `SENTRY_ENVIRONMENT` default value

### Specific Changes
```diff
- SENTRY_ENVIRONMENT=production
+ SENTRY_ENVIRONMENT=development  # Default for development; change for staging/production
```

### Impact
- **Local Development**: Sentry events will be tagged with `environment: development`
- **CI/CD**: No impact - production deployments should override this via environment-specific configs
- **Existing Users**: No breaking changes - only affects new `.env` file creation

---

## Checklist

- [x] Code follows project style guidelines
- [x] Changes have been tested locally
- [x] Documentation updated (inline comment added)
- [x] No breaking changes
- [x] `.env.example` reflects best practices for local development
- [x] Commit message follows conventional commits format
- [x] PR title is descriptive and follows convention

---

## Related Issues

Closes: N/A (Developer experience improvement)

## Deployment Notes

When deploying to staging or production:
```bash
# Override in your deployment config
SENTRY_ENVIRONMENT=production
```

Or update `.env` file directly on the deployment target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed the default environment setting from production to development and added an inline note clarifying this is the preferred default for local/dev use, with guidance to switch the setting for staging or production deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->