### PR TITLE
feat(db): consolidate duplicate get_db() implementations

### DIFF
--- a/app/api/deps/common.py
+++ b/app/api/deps/common.py
@@ -2,7 +2,7 @@ from fastapi import Depends, Header, HTTPException
 from sqlalchemy.orm import Session
 
 from app.core.settings import settings
-from app.infrastructure.db.session import get_db
+from app.api.deps.db import get_db
 
 
 def get_db_session(db: Session = Depends(get_db)) -> Session:

--- a/app/api/internal/business/activity.py
+++ b/app/api/internal/business/activity.py
@@ -11,7 +11,7 @@ from app.infrastructure.db.queries.activity_queries import (
     get_activity_summary,
     get_recent_activity,
 )
-from app.infrastructure.db.session import get_db
+from app.api.deps.db import get_db
 
 router = APIRouter()
 

--- a/app/api/internal/business/overview.py
+++ b/app/api/internal/business/overview.py
@@ -12,7 +12,7 @@ from app.infrastructure.db.queries.business_metrics import (
     get_user_metrics,
     get_vault_metrics,
 )
-from app.infrastructure.db.session import get_db
+from app.api.deps.db import get_db
 
 router = APIRouter()
 

--- a/app/api/internal/business/trends.py
+++ b/app/api/internal/business/trends.py
@@ -22,7 +22,7 @@ from app.infrastructure.db.queries.business_trends import (
     get_user_signup_trend,
     get_vault_provisioning_trend,
 )
-from app.infrastructure.db.session import get_db
+from app.api.deps.db import get_db
 
 router = APIRouter()
 

--- a/app/api/internal/ops/api_keys.py
+++ b/app/api/internal/ops/api_keys.py
@@ -24,7 +24,7 @@ from app.infrastructure.db.queries.api_key_queries import (
     list_api_keys,
     revoke_api_key,
 )
-from app.infrastructure.db.session import get_db
+from app.api.deps.db import get_db
 
 router = APIRouter()
 

--- a/app/api/internal/ops/audit.py
+++ b/app/api/internal/ops/audit.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.infrastructure.db.queries.audit_queries import get_audit_logs
-from app.infrastructure.db.session import get_db
+from app.api.deps.db import get_db
 
 router = APIRouter()
 

--- a/app/api/internal/ops/diagnostics.py
+++ b/app/api/internal/ops/diagnostics.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.infrastructure.db.session import get_db
+from app.api.deps.db import get_db
 from app.infrastructure.db.queries import system_metrics
 from app.infrastructure.messaging import websocket_manager
 

--- a/app/api/internal/ops/summary.py
+++ b/app/api/internal/ops/summary.py
@@ -20,7 +20,7 @@ from app.infrastructure.db.queries.security_metrics import (
     PIN_LOCKOUT_WARNING_THRESHOLD_24H,
     get_security_summary,
 )
-from app.infrastructure.db.session import get_db
+from app.api.deps.db import get_db
 
 router = APIRouter()
 

--- a/app/api/internal/security/alerts.py
+++ b/app/api/internal/security/alerts.py
@@ -37,7 +37,7 @@ from app.infrastructure.db.queries.security_metrics import (
     PIN_LOCKOUT_WARNING_THRESHOLD_24H,
     get_security_summary,
 )
-from app.infrastructure.db.session import get_db
+from app.api.deps.db import get_db
 
 router = APIRouter()
 

--- a/app/infrastructure/db/session.py
+++ b/app/infrastructure/db/session.py
@@ -19,12 +19,3 @@ def _get_sessionmaker():
 
 # Export SessionLocal for use in dependencies
 SessionLocal = _get_sessionmaker()
-
-
-def get_db():
-    """Provide database session for request."""
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()


### PR DESCRIPTION
Closes: #73 

## What's New in This PR

This PR eliminates code duplication by consolidating two identical `get_db()` function implementations into a single canonical function, improving code maintainability and reducing potential inconsistencies.

### Quick Setup

**For Backend Developers:**
```bash
# No action required - this is a pure refactor
# All existing code will work without changes
```

**For Frontend Developers:**
Not applicable - backend-only refactor with zero API changes.

---

## TL;DR

Removed duplicate `get_db()` function from `app/infrastructure/db/session.py` and updated 9 import statements across the codebase to use the canonical implementation in `app/api/deps/db.py`.

---

## Summary

**Problem:**
The codebase had two identical `get_db()` implementations:
1. `app/api/deps/db.py` (well-documented with type hints)
2. `app/infrastructure/db/session.py` (duplicate without type hints)

This created confusion about which function to import and violated the DRY (Don't Repeat Yourself) principle.

**Solution:**
- Removed the duplicate implementation from `app/infrastructure/db/session.py`
- Updated all 9 import statements to use the canonical location: `app/api/deps/db.py`
- Maintained `SessionLocal` export in `session.py` for dependency injection

**Impact:**
- Single source of truth for database session management
- Clearer dependency structure
- Easier to maintain and modify in the future

---

## Key Features

✅ **Single Canonical Implementation**: Only one `get_db()` exists in the codebase  
✅ **Consistent Imports**: All modules now import from `app.api.deps.db`  
✅ **Zero Breaking Changes**: Existing functionality unchanged  
✅ **Better Type Safety**: Using the well-typed implementation  
✅ **Improved Maintainability**: Future changes only need to be made in one place  

---

## Technical Changes

### Files Modified

**Deleted function:**
- `app/infrastructure/db/session.py` - Removed duplicate `get_db()` (9 lines)

**Updated imports (9 files):**
1. `app/api/deps/common.py`
2. `app/api/internal/business/activity.py`
3. `app/api/internal/business/overview.py`
4. `app/api/internal/business/trends.py`
5. `app/api/internal/ops/api_keys.py`
6. `app/api/internal/ops/audit.py`
7. `app/api/internal/ops/diagnostics.py`
8. `app/api/internal/ops/summary.py`
9. `app/api/internal/security/alerts.py`

### Change Pattern
```python
# Before
from app.infrastructure.db.session import get_db

# After
from app.api.deps.db import get_db
```

### Code Diff Summary
```
10 files changed, 9 insertions(+), 18 deletions(-)
- Removed: 9 lines (duplicate get_db function)
- Modified: 9 import statements
```

### Architecture Impact
- **Domain Layer**: No changes
- **Application Layer**: No changes
- **Infrastructure Layer**: Removed duplicate function
- **API Layer**: All modules now use canonical dependency

### Canonical Implementation
The canonical `get_db()` in `app/api/deps/db.py` provides:
- Type hints (`Generator[Session, None, None]`)
- Complete docstring with usage examples
- Proper session lifecycle management (yield pattern)
- Automatic session cleanup via try/finally

---

## Checklist

- [x] Code follows project style guidelines
- [x] Single source of truth established for `get_db()`
- [x] All imports point to canonical location (`app/api/deps/db.py`)
- [x] No breaking changes - pure refactor
- [x] Type hints maintained
- [x] Clean Architecture principles preserved
- [x] Documentation updated (inline docstrings)
- [x] Commit message follows conventional commits format
- [x] Resolves Issue #73

---

## Related Issues

Resolves: **Issue #73** - Consolidate duplicate `get_db()` implementations into a single canonical function

---

## Testing Notes

**Before merge:**
- [ ] All existing tests should pass without modifications
- [ ] No new tests required (pure refactor with identical behavior)
- [ ] Verify imports work correctly: `make test`

**Validation:**
```bash
# Verify only one get_db() exists
grep -r "def get_db()" app/ | grep -v __pycache__
# Should return only: app/api/deps/db.py

# Verify all imports are correct
grep -r "from.*import get_db" app/ | grep -v __pycache__
# Should all point to: app.api.deps.db
```

---

## Migration Guide

**For developers with existing branches:**
```bash
# If you have import errors after merging:
# 1. Update your imports from:
from app.infrastructure.db.session import get_db

# 2. To:
from app.api.deps.db import get_db

# That's it!
```

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal dependency management structure for improved code organization and maintainability.

---

**Note:** This release contains only internal code restructuring with no changes to user-facing functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->