### PR TITLE
fix(logging): remove PII from exception strings and API logs

### DIFF
--- a/app/api/v1/access.py
+++ b/app/api/v1/access.py
@@ -64,7 +64,7 @@ async def add_vault_member(
         if target_user is None:
             raise UserNotFoundError(payload.user_id)
     except UserNotFoundError as e:
-        logger.warning("user_not_found", error=str(e))
+        logger.warning("user_not_found")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
 
     try:
@@ -92,14 +92,14 @@ async def add_vault_member(
         )
 
     except (VaultNotFoundError, UserNotFoundError) as e:
-        logger.warning("resource_not_found", error=str(e))
+        logger.warning("resource_not_found")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
     except (UnauthorizedVaultAccessError, InsufficientPermissionsError) as e:
-        logger.warning("access_denied", error=str(e))
+        logger.warning("access_denied")
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
     except ValueError as e:
         # e.g., attempting to add the owner as a member
-        logger.warning("validation_error", error=str(e))
+        logger.warning("validation_error")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 
@@ -127,13 +127,13 @@ async def remove_vault_member(
             ),
         )
     except (VaultNotFoundError, UserNotFoundError) as e:
-        logger.warning("resource_not_found", error=str(e))
+        logger.warning("resource_not_found")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
     except (UnauthorizedVaultAccessError, InsufficientPermissionsError) as e:
-        logger.warning("access_denied", error=str(e))
+        logger.warning("access_denied")
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
     except CannotRemoveOwnerError as e:
-        logger.warning("validation_error", error=str(e))
+        logger.warning("validation_error")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 
@@ -170,7 +170,7 @@ async def list_vault_members(
 
         if len(members) != len(result.members):
             missing_ids = set(user_ids) - set(users.keys())
-            logger.warning("resource_not_found", error=f"Missing user data for IDs: {', '.join(missing_ids)}")
+            logger.warning("resource_not_found", missing_user_count=len(missing_ids))
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
 
         return MemberListResponse(
@@ -179,8 +179,8 @@ async def list_vault_members(
         )
 
     except (VaultNotFoundError, UserNotFoundError) as e:
-        logger.warning("resource_not_found", error=str(e))
+        logger.warning("resource_not_found")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
     except (UnauthorizedVaultAccessError, InsufficientPermissionsError) as e:
-        logger.warning("access_denied", error=str(e))
+        logger.warning("access_denied")
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")

--- a/app/domain/exceptions.py
+++ b/app/domain/exceptions.py
@@ -9,7 +9,7 @@ class VaultAuthorizationError(Exception):
 class UnauthorizedVaultAccessError(VaultAuthorizationError):
     """Raised when user tries to access a vault they don't have permission for."""
     def __init__(self, user_id: str, vault_id: str):
-        super().__init__(f"User {user_id} does not have access to vault {vault_id}")
+        super().__init__("Unauthorized vault access")
         self.user_id = user_id
         self.vault_id = vault_id
 
@@ -17,9 +17,7 @@ class UnauthorizedVaultAccessError(VaultAuthorizationError):
 class InsufficientPermissionsError(VaultAuthorizationError):
     """Raised when user's role doesn't have sufficient permissions."""
     def __init__(self, user_id: str, vault_id: str, role: str, required_action: str):
-        super().__init__(
-            f"User {user_id} with role {role} cannot perform '{required_action}' on vault {vault_id}"
-        )
+        super().__init__("Insufficient permissions for requested action")
         self.user_id = user_id
         self.vault_id = vault_id
         self.role = role
@@ -29,21 +27,21 @@ class InsufficientPermissionsError(VaultAuthorizationError):
 class CannotRemoveOwnerError(VaultAuthorizationError):
     """Raised when attempting to remove the vault owner."""
     def __init__(self, vault_id: str):
-        super().__init__(f"Cannot remove owner from vault {vault_id}")
+        super().__init__("Cannot remove vault owner")
         self.vault_id = vault_id
 
 
 class UserNotFoundError(Exception):
     """Raised when target user doesn't exist."""
     def __init__(self, user_id: str):
-        super().__init__(f"User {user_id} not found")
+        super().__init__("User not found")
         self.user_id = user_id
 
 
 class VaultNotFoundError(Exception):
     """Raised when vault doesn't exist."""
     def __init__(self, vault_id: str):
-        super().__init__(f"Vault {vault_id} not found")
+        super().__init__("Vault not found")
         self.vault_id = vault_id
 
 
@@ -55,7 +53,7 @@ class PINError(Exception):
 class PINNotSetError(PINError):
     """Raised when a PIN has not been configured for the vault."""
     def __init__(self, vault_id: str):
-        super().__init__(f"PIN is not set for vault {vault_id}")
+        super().__init__("PIN is not set for vault")
         self.vault_id = vault_id
 
 
@@ -69,9 +67,9 @@ class InvalidPINError(PINError):
 class PINLockedOutError(PINError):
     """Raised when PIN attempts are locked out due to too many failures."""
     def __init__(self, vault_id: str, attempts_remaining: int | None = None):
-        detail = "PIN entry locked due to too many failed attempts"
         if attempts_remaining is not None:
-            detail = f"{detail}; attempts remaining: {attempts_remaining}"
-        super().__init__(f"{detail} for vault {vault_id}")
+            super().__init__(f"PIN entry locked due to too many failed attempts; attempts remaining: {attempts_remaining}")
+        else:
+            super().__init__("PIN entry locked due to too many failed attempts")
         self.vault_id = vault_id
         self.attempts_remaining = attempts_remaining

--- a/app/tests/api/test_access_logging_pii.py
+++ b/app/tests/api/test_access_logging_pii.py
@@ -1,0 +1,105 @@
+"""Tests to verify API logging doesn't expose PII."""
+from datetime import datetime, timezone
+from dataclasses import replace
+
+from app.domain.models.user import User
+from app.domain.models.vault_authorization import VaultAuthorization
+from app.domain.value_objects.vault_role import VaultRole
+from app.infrastructure.db.repositories.in_memory_vault_authorization_repository import (
+    InMemoryVaultAuthorizationRepository,
+)
+
+
+def _seed_user(repo, user_id: str, email: str, full_name: str | None = None):
+    user = User(
+        id=user_id,
+        email=email,
+        password_hash="x",
+        full_name=full_name,
+        created_at=datetime.now(timezone.utc),
+    )
+    repo.create(user)
+    return user
+
+
+def _set_vault_owner(vault_repo, vault_id: str, owner_id: str):
+    vault = vault_repo._vaults[vault_id]
+    vault_repo._vaults[vault_id] = replace(vault, owner_id=owner_id)
+
+
+def test_list_members_missing_users_no_raw_ids_in_logs(
+    client, vault_repo, vault_auth_repo: InMemoryVaultAuthorizationRepository, user_repo, capsys
+):
+    """Verify that when users are missing, logs don't contain raw user IDs."""
+    owner_id = "test-user-id"
+    _set_vault_owner(vault_repo, "demo-vault-1", owner_id)
+    _seed_user(user_repo, owner_id, "owner@example.com")
+    
+    # Create authorization for a user that doesn't exist in user_repo
+    vault_auth_repo.create(
+        VaultAuthorization(
+            id="auth-1",
+            vault_id="demo-vault-1",
+            user_id="missing-user-999",
+            role=VaultRole.MEMBER,
+            granted_by=owner_id,
+            granted_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+    )
+    
+    resp = client.get("/api/v1/vaults/demo-vault-1/members")
+    
+    assert resp.status_code == 404
+    
+    # Capture stdout/stderr where structlog outputs
+    captured = capsys.readouterr()
+    log_output = captured.out + captured.err
+    
+    # Should have logged the warning with count
+    assert "resource_not_found" in log_output
+    assert "missing_user_count=1" in log_output
+    
+    # Should NOT contain the raw user ID
+    assert "missing-user-999" not in log_output
+
+
+def test_add_member_exception_no_raw_ids_in_logs(client, vault_repo, user_repo, capsys):
+    """Verify exceptions don't leak user/vault IDs in logs."""
+    # Don't seed the owner - this will trigger UnauthorizedVaultAccessError
+    _seed_user(user_repo, "test-user-id", "test@example.com")
+    _seed_user(user_repo, "member-1", "member1@example.com")
+    
+    resp = client.post(
+        "/api/v1/vaults/demo-vault-1/members",
+        json={"user_id": "member-1", "role": "MEMBER"},
+    )
+    
+    assert resp.status_code == 403
+    
+    # Capture stdout/stderr
+    captured = capsys.readouterr()
+    log_output = captured.out + captured.err
+    
+    # Verify logs don't contain raw IDs
+    assert "demo-vault-1" not in log_output
+    assert "member-1" not in log_output
+    assert "test-user-id" not in log_output
+
+
+def test_remove_member_exception_no_raw_ids_in_logs(client, vault_repo, user_repo, capsys):
+    """Verify remove member exceptions don't leak IDs in logs."""
+    # Don't seed the owner - this will trigger UnauthorizedVaultAccessError
+    _seed_user(user_repo, "test-user-id", "test@example.com")
+    
+    resp = client.delete("/api/v1/vaults/demo-vault-1/members/some-member")
+    
+    assert resp.status_code == 403
+    
+    # Capture stdout/stderr
+    captured = capsys.readouterr()
+    log_output = captured.out + captured.err
+    
+    # Verify logs don't contain raw IDs
+    assert "demo-vault-1" not in log_output
+    assert "some-member" not in log_output
+    assert "test-user-id" not in log_output

--- a/app/tests/domain/test_exceptions_pii.py
+++ b/app/tests/domain/test_exceptions_pii.py
@@ -1,0 +1,113 @@
+"""Tests to verify domain exceptions don't leak PII in string representations."""
+from app.domain.exceptions import (
+    UnauthorizedVaultAccessError,
+    InsufficientPermissionsError,
+    CannotRemoveOwnerError,
+    UserNotFoundError,
+    VaultNotFoundError,
+    PINNotSetError,
+    PINLockedOutError,
+)
+
+
+def test_unauthorized_vault_access_no_pii_in_str():
+    """Verify UnauthorizedVaultAccessError doesn't expose user_id or vault_id in __str__."""
+    exc = UnauthorizedVaultAccessError(user_id="user-123", vault_id="vault-456")
+    
+    error_str = str(exc)
+    assert "user-123" not in error_str
+    assert "vault-456" not in error_str
+    assert "Unauthorized vault access" in error_str
+    
+    # Identifiers should still be accessible via properties
+    assert exc.user_id == "user-123"
+    assert exc.vault_id == "vault-456"
+
+
+def test_insufficient_permissions_no_pii_in_str():
+    """Verify InsufficientPermissionsError doesn't expose identifiers in __str__."""
+    exc = InsufficientPermissionsError(
+        user_id="user-789",
+        vault_id="vault-012",
+        role="VIEWER",
+        required_action="delete_vault"
+    )
+    
+    error_str = str(exc)
+    assert "user-789" not in error_str
+    assert "vault-012" not in error_str
+    assert "Insufficient permissions" in error_str
+    
+    # Identifiers should still be accessible
+    assert exc.user_id == "user-789"
+    assert exc.vault_id == "vault-012"
+    assert exc.role == "VIEWER"
+    assert exc.required_action == "delete_vault"
+
+
+def test_cannot_remove_owner_no_pii_in_str():
+    """Verify CannotRemoveOwnerError doesn't expose vault_id in __str__."""
+    exc = CannotRemoveOwnerError(vault_id="vault-345")
+    
+    error_str = str(exc)
+    assert "vault-345" not in error_str
+    assert "Cannot remove vault owner" in error_str
+    
+    assert exc.vault_id == "vault-345"
+
+
+def test_user_not_found_no_pii_in_str():
+    """Verify UserNotFoundError doesn't expose user_id in __str__."""
+    exc = UserNotFoundError(user_id="user-678")
+    
+    error_str = str(exc)
+    assert "user-678" not in error_str
+    assert "User not found" in error_str
+    
+    assert exc.user_id == "user-678"
+
+
+def test_vault_not_found_no_pii_in_str():
+    """Verify VaultNotFoundError doesn't expose vault_id in __str__."""
+    exc = VaultNotFoundError(vault_id="vault-901")
+    
+    error_str = str(exc)
+    assert "vault-901" not in error_str
+    assert "Vault not found" in error_str
+    
+    assert exc.vault_id == "vault-901"
+
+
+def test_pin_not_set_no_pii_in_str():
+    """Verify PINNotSetError doesn't expose vault_id in __str__."""
+    exc = PINNotSetError(vault_id="vault-234")
+    
+    error_str = str(exc)
+    assert "vault-234" not in error_str
+    assert "PIN is not set" in error_str
+    
+    assert exc.vault_id == "vault-234"
+
+
+def test_pin_locked_out_no_pii_in_str():
+    """Verify PINLockedOutError doesn't expose vault_id in __str__."""
+    exc = PINLockedOutError(vault_id="vault-567", attempts_remaining=0)
+    
+    error_str = str(exc)
+    assert "vault-567" not in error_str
+    assert "PIN entry locked" in error_str
+    
+    assert exc.vault_id == "vault-567"
+    assert exc.attempts_remaining == 0
+
+
+def test_pin_locked_out_no_attempts_remaining():
+    """Verify PINLockedOutError without attempts_remaining parameter."""
+    exc = PINLockedOutError(vault_id="vault-890")
+    
+    error_str = str(exc)
+    assert "vault-890" not in error_str
+    assert "PIN entry locked" in error_str
+    
+    assert exc.vault_id == "vault-890"
+    assert exc.attempts_remaining is None


### PR DESCRIPTION
## Summary
Removes Personally Identifiable Information (PII) from domain exception string representations and API log messages to comply with privacy best practices and regulatory requirements (GDPR, etc.).

## Motivation
The codebase currently logs raw user IDs and vault IDs in multiple places:
- Domain exceptions include identifiers in their `__str__()` representations
- `app/api/v1/access.py` logs raw `missing_ids` (user IDs) directly
- Multiple log statements use `error=str(e)` which exposes identifiers from exception messages

This violates privacy best practices and could expose sensitive user information in log aggregation systems, monitoring tools, and error tracking platforms.

## Changes
- **Domain Layer (`app/domain/exceptions.py`):**
  - Updated all 7 exceptions to return generic messages without IDs in `__str__()`
  - Identifiers remain accessible via properties for internal use
  - Affected: `UnauthorizedVaultAccessError`, `InsufficientPermissionsError`, `CannotRemoveOwnerError`, `UserNotFoundError`, `VaultNotFoundError`, `PINNotSetError`, `PINLockedOutError`

- **API Layer (`app/api/v1/access.py`):**
  - Line 173: Replaced raw `missing_ids` logging with count-only (`missing_user_count=len(missing_ids)`)
  - Lines 67, 95, 98, 102, 130, 133, 136, 182, 185: Removed `error=str(e)` from logger.warning calls
  - Use structured logging with safe context (event types, counts, not IDs)

- **Tests:**
  - Added `app/tests/domain/test_exceptions_pii.py` - 8 tests verifying exceptions don't leak IDs
  - Added `app/tests/api/test_access_logging_pii.py` - 3 tests verifying API logs don't contain raw IDs

## Testing
- [x] Unit tests added/updated (11 new tests)
- [x] Integration tests added/updated (API logging tests use capsys)
- [x] Manual testing performed (verified log output format)

**Test Results:**
- All 259 tests pass (including 11 new PII protection tests)
- Verified structured logging shows `missing_user_count=1` instead of raw IDs
- Confirmed exception messages are generic (e.g., "User not found" instead of "User xyz-123 not found")

## Architecture Impact
- [x] Domain layer changes (exception string representations)
- [ ] Application layer changes
- [ ] Infrastructure layer changes
- [x] API layer changes (logging statements only)
- [ ] Database migration included

## Checklist
- [x] Tests pass locally (`make test`)
- [x] Code follows style guidelines
- [ ] Documentation updated (no docs changes needed)
- [ ] Migration is reversible (no migration)
- [x] No breaking changes
- [x] Observability added (improved structured logging with safe fields)

## Example Log Output

**Before:**
```
[warning] resource_not_found error="Missing user data for IDs: user-123, user-456"
[warning] access_denied error="User xyz-789 does not have access to vault abc-123"
```

**After:**
```
[warning] resource_not_found missing_user_count=2 request_id=...
[warning] access_denied request_id=...
```

## Related Issue
Resolves #75


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Simplified logging calls across exception handlers, replacing detailed error traces with concise warning messages.
  * Updated exception messages to use consistent, generic descriptions instead of including resource-specific identifiers.

* **Tests**
  * Added tests for API access logging to validate output formatting meets requirements.
  * Added tests for exception messages to ensure consistent formatting and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->