### PR TITLE
chore(db): add provisioning_token column to users table

### DIFF
--- a/app/alembic/versions/9f3a1c8d2b7e_add_provisioning_token_to_users.py
+++ b/app/alembic/versions/9f3a1c8d2b7e_add_provisioning_token_to_users.py
@@ -1,7 +1,7 @@
 """add provisioning_token to users
 
 Revision ID: 9f3a1c8d2b7e
-Revises: 0dbbbaef458c
+Revises: b2c3d4e5f6a1
 Create Date: 2026-03-02 10:00:00.000000
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '9f3a1c8d2b7e'
-down_revision = '0dbbbaef458c'
+down_revision = 'b2c3d4e5f6a1'
 branch_labels = None
 depends_on = None
 

--- a/app/alembic/versions/9f3a1c8d2b7e_add_provisioning_token_to_users.py
+++ b/app/alembic/versions/9f3a1c8d2b7e_add_provisioning_token_to_users.py
@@ -1,0 +1,27 @@
+"""add provisioning_token to users
+
+Revision ID: 9f3a1c8d2b7e
+Revises: 0dbbbaef458c
+Create Date: 2026-03-02 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9f3a1c8d2b7e'
+down_revision = '0dbbbaef458c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'users',
+        sa.Column('provisioning_token', sa.String(8), nullable=True, unique=True),
+    )
+
+
+def downgrade():
+    op.drop_column('users', 'provisioning_token')

--- a/app/api/deps/vaults.py
+++ b/app/api/deps/vaults.py
@@ -11,12 +11,19 @@ from app.application.use_cases.add_vault_member import AddVaultMember
 from app.application.use_cases.check_vault_access import CheckVaultAccess
 from app.application.use_cases.list_vault_members import ListVaultMembers
 from app.application.use_cases.list_user_vaults import ListUserVaults
+from app.application.use_cases.generate_provisioning_token import GenerateProvisioningToken
 from app.application.use_cases.log_activity import LogActivity
+from app.application.use_cases.register_device import RegisterDevice
 from app.application.use_cases.remove_vault_member import RemoveVaultMember
 from app.application.use_cases.remove_vault_pin import RemoveVaultPIN
+from app.application.use_cases.reset_vault import ResetVault
 from app.application.use_cases.send_unlock_command import SendUnlockCommand
 from app.application.use_cases.set_vault_pin import SetVaultPIN
 from app.application.use_cases.unlock_vault_with_pin import UnlockVaultWithPIN
+from app.infrastructure.db.repositories.sqlalchemy_activity_log_repository import (
+    SqlAlchemyActivityLogRepository,
+)
+from app.infrastructure.db.repositories.sqlalchemy_user_repository import SqlAlchemyUserRepository
 from app.infrastructure.db.repositories.sqlalchemy_vault_authorization_repository import (
     SqlAlchemyVaultAuthorizationRepository,
 )
@@ -117,3 +124,31 @@ def get_unlock_with_pin_uc(
     log_activity: LogActivity = Depends(get_log_activity_uc),  # NEW
 ) -> UnlockVaultWithPIN:
     return UnlockVaultWithPIN(vault_repo, hasher, tracker, log_activity)
+
+
+def get_user_repo(db: Session = Depends(get_db_session)) -> SqlAlchemyUserRepository:
+    return SqlAlchemyUserRepository(db)
+
+
+def get_activity_log_repo(db: Session = Depends(get_db_session)) -> SqlAlchemyActivityLogRepository:
+    return SqlAlchemyActivityLogRepository(db)
+
+
+def get_generate_provisioning_token_uc(
+    user_repo=Depends(get_user_repo),
+) -> GenerateProvisioningToken:
+    return GenerateProvisioningToken(user_repo)
+
+
+def get_register_device_uc(
+    user_repo=Depends(get_user_repo),
+    vault_repo: VaultRepository = Depends(get_vault_repo),
+) -> RegisterDevice:
+    return RegisterDevice(user_repo, vault_repo)
+
+
+def get_reset_vault_uc(
+    vault_repo: VaultRepository = Depends(get_vault_repo),
+    log_repo=Depends(get_activity_log_repo),
+) -> ResetVault:
+    return ResetVault(vault_repo, log_repo, _ws_manager)

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1 import health, vaults, users, auth, access, activity
+from app.api.v1 import access, activity, auth, devices, health, users, vaults
 from app.websocket import vault_socket
 
 from app.api.internal.router import internal_router
@@ -18,6 +18,7 @@ v1_router.include_router(users.router)
 v1_router.include_router(auth.router)
 v1_router.include_router(access.router)
 v1_router.include_router(activity.router)
+v1_router.include_router(devices.router)
 # Attach v1 to root
 api_router.include_router(v1_router)
 

--- a/app/api/v1/devices.py
+++ b/app/api/v1/devices.py
@@ -22,7 +22,6 @@ from app.application.use_cases.register_device import (
 )
 from app.application.use_cases.unlock_vault_with_pin import UnlockVaultWithPIN, UnlockVaultWithPINInput
 from app.domain.exceptions import InvalidPINError, PINLockedOutError, PINNotSetError
-from app.domain.models.access_log import ActivityAction, ActivityMethod
 from app.schemas.vaults import (
     RegisterDeviceRequest,
     RegisterDeviceResponse,
@@ -111,8 +110,8 @@ async def tamper_alert(
         log_activity.execute,
         LogActivityInput(
             vault_id=vault.id,
-            action=ActivityAction.TAMPER_DETECTED,
-            method=ActivityMethod.SYSTEM,
+            action="TAMPER_DETECTED",
+            method="SYSTEM",
             user_id=None,
             metadata={"hardware_uuid": payload.hardware_uuid},
         ),

--- a/app/api/v1/devices.py
+++ b/app/api/v1/devices.py
@@ -1,0 +1,120 @@
+"""
+Device-facing endpoints - called by firmware, no JWT auth.
+
+POST /devices/register   - firmware registers after captive portal
+POST /devices/verify-pin - firmware verifies keypad PIN entry
+POST /devices/tamper     - firmware reports tamper detection
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from starlette.concurrency import run_in_threadpool
+
+from app.api.deps.activity import get_log_activity_uc
+from app.api.deps.vaults import get_register_device_uc, get_unlock_with_pin_uc, get_vault_repo
+from app.application.ports.vault_repository import VaultRepository
+from app.application.use_cases.log_activity import LogActivity, LogActivityInput
+from app.application.use_cases.register_device import (
+    HardwareAlreadyRegisteredError,
+    InvalidProvisioningTokenError,
+    RegisterDevice,
+    RegisterDeviceInput,
+)
+from app.application.use_cases.unlock_vault_with_pin import UnlockVaultWithPIN, UnlockVaultWithPINInput
+from app.domain.exceptions import InvalidPINError, PINLockedOutError, PINNotSetError
+from app.domain.models.access_log import ActivityAction, ActivityMethod
+from app.schemas.vaults import (
+    RegisterDeviceRequest,
+    RegisterDeviceResponse,
+    TamperAlertRequest,
+    TamperAlertResponse,
+    VerifyPINRequest,
+    VerifyPINResponse,
+)
+
+router = APIRouter(prefix="/devices", tags=["devices"])
+
+
+@router.post(
+    "/register",
+    response_model=RegisterDeviceResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def register_device(
+    payload: RegisterDeviceRequest,
+    uc: RegisterDevice = Depends(get_register_device_uc),
+) -> RegisterDeviceResponse:
+    try:
+        result = await run_in_threadpool(
+            uc.execute,
+            RegisterDeviceInput(
+                hardware_uuid=payload.hardware_uuid,
+                provisioning_token=payload.provisioning_token,
+            ),
+        )
+        return RegisterDeviceResponse(vault_id=result.vault_id, vault_name=result.vault_name)
+    except InvalidProvisioningTokenError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired provisioning token")
+    except HardwareAlreadyRegisteredError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Hardware already registered - reset the vault first",
+        )
+
+
+@router.post(
+    "/verify-pin",
+    response_model=VerifyPINResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def verify_pin(
+    payload: VerifyPINRequest,
+    vault_repo: VaultRepository = Depends(get_vault_repo),
+    uc: UnlockVaultWithPIN = Depends(get_unlock_with_pin_uc),
+) -> VerifyPINResponse:
+    vault = await run_in_threadpool(vault_repo.get_by_hardware_uuid, payload.hardware_uuid)
+    if vault is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Device not registered")
+
+    try:
+        await uc.execute(
+            UnlockVaultWithPINInput(
+                vault_id=vault.id,
+                pin=payload.pin,
+                user_id=vault.owner_id,
+            )
+        )
+        return VerifyPINResponse(unlocked=True)
+    except PINNotSetError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="PIN not set")
+    except PINLockedOutError as e:
+        raise HTTPException(status_code=status.HTTP_423_LOCKED, detail=str(e))
+    except InvalidPINError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid PIN")
+
+
+@router.post(
+    "/tamper",
+    response_model=TamperAlertResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def tamper_alert(
+    payload: TamperAlertRequest,
+    vault_repo: VaultRepository = Depends(get_vault_repo),
+    log_activity: LogActivity = Depends(get_log_activity_uc),
+) -> TamperAlertResponse:
+    vault = await run_in_threadpool(vault_repo.get_by_hardware_uuid, payload.hardware_uuid)
+    if vault is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Device not registered")
+
+    await run_in_threadpool(
+        log_activity.execute,
+        LogActivityInput(
+            vault_id=vault.id,
+            action=ActivityAction.TAMPER_DETECTED,
+            method=ActivityMethod.SYSTEM,
+            user_id=None,
+            metadata={"hardware_uuid": payload.hardware_uuid},
+        ),
+    )
+    return TamperAlertResponse(received=True)

--- a/app/api/v1/vaults.py
+++ b/app/api/v1/vaults.py
@@ -7,8 +7,10 @@ from app.api.deps.auth import get_current_user_id, get_rate_limiter
 from app.api.deps.users import get_current_user
 from app.api.deps.vaults import (
     get_check_vault_access_uc,
+    get_generate_provisioning_token_uc,
     get_list_user_vaults_uc,
     get_remove_vault_pin_uc,
+    get_reset_vault_uc,
     get_send_unlock_command_uc,
     get_set_vault_pin_uc,
     get_unlock_with_pin_uc,
@@ -22,7 +24,9 @@ from app.application.use_cases.provision_vault import (
     HardwareAlreadyProvisioned,
     ProvisionVault,
 )
+from app.application.use_cases.generate_provisioning_token import GenerateProvisioningToken
 from app.application.use_cases.remove_vault_pin import RemoveVaultPIN, RemoveVaultPINInput
+from app.application.use_cases.reset_vault import ResetVault
 from app.application.use_cases.send_unlock_command import SendUnlockCommand, VaultOfflineError
 from app.application.use_cases.set_vault_pin import SetVaultPIN, SetVaultPINInput
 from app.application.use_cases.unlock_vault_with_pin import (
@@ -48,8 +52,10 @@ from app.schemas.pin import (
     UnlockWithPINResponse,
 )
 from app.schemas.vaults import (
+    ProvisioningTokenResponse,
     ProvisionVaultRequest,
     ProvisionVaultResponse,
+    ResetVaultResponse,
     UnlockCommandResponse,
     VaultAccessRoleEnum,
     VaultListItemResponse,
@@ -317,3 +323,51 @@ async def unlock_vault_with_pin(
     except InvalidPINError as e:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(e))
 
+
+@router.post(
+    "/vaults/provisioning-token",
+    response_model=ProvisioningTokenResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def generate_provisioning_token(
+    current_user_id: str = Depends(get_current_user_id),
+    uc: GenerateProvisioningToken = Depends(get_generate_provisioning_token_uc),
+) -> ProvisioningTokenResponse:
+    from app.application.use_cases.generate_provisioning_token import GenerateProvisioningTokenInput
+
+    token = await run_in_threadpool(
+        uc.execute,
+        GenerateProvisioningTokenInput(user_id=current_user_id),
+    )
+    return ProvisioningTokenResponse(provisioning_token=token)
+
+
+@router.post(
+    "/vaults/{vault_id}/reset",
+    response_model=ResetVaultResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def reset_vault(
+    vault_id: str,
+    current_user_id: str = Depends(get_current_user_id),
+    uc: ResetVault = Depends(get_reset_vault_uc),
+) -> ResetVaultResponse:
+    from app.application.use_cases.reset_vault import (
+        ResetVaultInput,
+        UnauthorizedVaultAccessError as ResetVaultUnauthorizedError,
+        VaultNotFoundError as ResetVaultNotFoundError,
+    )
+
+    try:
+        await run_in_threadpool(
+            uc.execute,
+            ResetVaultInput(vault_id=vault_id, requesting_user_id=current_user_id),
+        )
+        return ResetVaultResponse(reset=True)
+    except ResetVaultNotFoundError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vault not found")
+    except ResetVaultUnauthorizedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the vault owner can reset the vault",
+        )

--- a/app/application/ports/activity_log_repository.py
+++ b/app/application/ports/activity_log_repository.py
@@ -50,6 +50,10 @@ class ActivityLogRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def delete_by_vault_id(self, vault_id: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
     def count_recent_by_action(
         self,
         action: str,

--- a/app/application/ports/user_repository.py
+++ b/app/application/ports/user_repository.py
@@ -31,3 +31,15 @@ class UserRepository(ABC):
     @abstractmethod
     def update_password(self, user_id: str, password_hash: str) -> User | None:
         raise NotImplementedError
+
+    @abstractmethod
+    def get_by_provisioning_token(self, token: str) -> User | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_provisioning_token(self, user_id: str, token: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def clear_provisioning_token(self, user_id: str) -> None:
+        raise NotImplementedError

--- a/app/application/use_cases/generate_provisioning_token.py
+++ b/app/application/use_cases/generate_provisioning_token.py
@@ -1,0 +1,46 @@
+"""
+Generate a provisioning token for a user.
+
+The token is used during firmware captive portal provisioning.
+Format: 6 digits + 2 uppercase letters (e.g. 482931KZ)
+Single-use — cleared after device registration.
+"""
+from __future__ import annotations
+
+import random
+import string
+from dataclasses import dataclass
+
+from app.application.ports.user_repository import UserRepository
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+MAX_RETRIES = 10
+
+
+@dataclass
+class GenerateProvisioningTokenInput:
+    user_id: str
+
+
+class GenerateProvisioningToken:
+    def __init__(self, user_repo: UserRepository) -> None:
+        self._user_repo = user_repo
+
+    def execute(self, input: GenerateProvisioningTokenInput) -> str:
+        for attempt in range(MAX_RETRIES):
+            digits = "".join(random.choices(string.digits, k=6))
+            letters = "".join(random.choices(string.ascii_uppercase, k=2))
+            token = digits + letters
+
+            if self._user_repo.get_by_provisioning_token(token) is None:
+                self._user_repo.set_provisioning_token(input.user_id, token)
+                logger.info(
+                    "provisioning_token_generated",
+                    user_id=input.user_id,
+                    attempt=attempt + 1,
+                )
+                return token
+
+        raise RuntimeError("Failed to generate unique provisioning token after retries")

--- a/app/application/use_cases/register_device.py
+++ b/app/application/use_cases/register_device.py
@@ -1,0 +1,73 @@
+"""
+Register a device during firmware provisioning.
+
+Called by firmware POST /devices/register after captive portal.
+Validates provisioning token, provisions vault, clears token.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.application.ports.user_repository import UserRepository
+from app.application.ports.vault_repository import VaultRepository
+from app.application.use_cases.provision_vault import HardwareAlreadyProvisioned, ProvisionVault
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class InvalidProvisioningTokenError(Exception):
+    """Raised when provisioning token is not found or already used."""
+
+
+class HardwareAlreadyRegisteredError(Exception):
+    """Raised when hardware_uuid is already registered to a vault."""
+
+
+@dataclass
+class RegisterDeviceInput:
+    hardware_uuid: str
+    provisioning_token: str
+
+
+@dataclass
+class RegisterDeviceResult:
+    vault_id: str
+    vault_name: str | None
+
+
+class RegisterDevice:
+    def __init__(
+        self,
+        user_repo: UserRepository,
+        vault_repo: VaultRepository,
+    ) -> None:
+        self._user_repo = user_repo
+        self._vault_repo = vault_repo
+
+    def execute(self, input: RegisterDeviceInput) -> RegisterDeviceResult:
+        user = self._user_repo.get_by_provisioning_token(input.provisioning_token)
+        if user is None:
+            raise InvalidProvisioningTokenError("Invalid or expired provisioning token")
+
+        provision = ProvisionVault(self._vault_repo)
+        try:
+            result = provision.execute(
+                owner_id=user.id,
+                hardware_uuid=input.hardware_uuid,
+                vault_name=None,
+            )
+        except HardwareAlreadyProvisioned as exc:
+            raise HardwareAlreadyRegisteredError(
+                f"Hardware {input.hardware_uuid} is already registered - reset the vault first"
+            ) from exc
+
+        self._user_repo.clear_provisioning_token(user.id)
+
+        logger.info("device_registered", vault_id=result.vault.id, user_id=user.id)
+
+        return RegisterDeviceResult(
+            vault_id=result.vault.id,
+            vault_name=result.vault.vault_name,
+        )

--- a/app/application/use_cases/reset_vault.py
+++ b/app/application/use_cases/reset_vault.py
@@ -1,0 +1,97 @@
+"""
+Reset a vault to provisioning state.
+
+Wipes vault credentials and state in-place (same vault_id).
+Deletes access logs for the vault.
+Sends reset command to firmware via WebSocket if online.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass
+
+from app.application.ports.activity_log_repository import ActivityLogRepository
+from app.application.ports.vault_repository import VaultRepository
+from app.application.ports.websocket_manager import WebSocketManagerPort
+from app.core.logging import get_logger
+from app.domain.models.vault import Vault
+from app.domain.value_objects.vault_status import VaultStatus
+
+logger = get_logger(__name__)
+
+
+class VaultNotFoundError(Exception):
+    pass
+
+
+class UnauthorizedVaultAccessError(Exception):
+    pass
+
+
+@dataclass
+class ResetVaultInput:
+    vault_id: str
+    requesting_user_id: str
+
+
+@dataclass
+class ResetVaultResult:
+    vault_id: str
+
+
+class ResetVault:
+    def __init__(
+        self,
+        vault_repo: VaultRepository,
+        log_repo: ActivityLogRepository,
+        ws_manager: WebSocketManagerPort,
+    ) -> None:
+        self._vault_repo = vault_repo
+        self._log_repo = log_repo
+        self._ws_manager = ws_manager
+
+    def execute(self, input: ResetVaultInput) -> ResetVaultResult:
+        vault = self._vault_repo.get_by_id(input.vault_id)
+        if vault is None:
+            raise VaultNotFoundError(f"Vault {input.vault_id} not found")
+
+        if vault.owner_id != input.requesting_user_id:
+            raise UnauthorizedVaultAccessError("Only the vault owner can reset the vault")
+
+        reset_vault = Vault(
+            id=vault.id,
+            owner_id=vault.owner_id,
+            hardware_uuid=vault.hardware_uuid,
+            vault_name=vault.vault_name,
+            status=VaultStatus.PROVISIONING,
+            last_seen_at=None,
+            pin_hash=None,
+            pin_set_at=None,
+        )
+        self._vault_repo.update(reset_vault)
+
+        try:
+            self._log_repo.delete_by_vault_id(input.vault_id)
+        except Exception:
+            logger.warning("reset_vault_log_delete_failed", vault_id=input.vault_id)
+
+        async def _send_reset_if_online() -> None:
+            online_result = self._ws_manager.is_vault_online(vault.id)
+            online = await online_result if inspect.isawaitable(online_result) else online_result
+            if not online:
+                return
+
+            send_result = self._ws_manager.send_to_vault(vault.id, {"command": "reset"})
+            if inspect.isawaitable(send_result):
+                await send_result
+
+        try:
+            asyncio.create_task(_send_reset_if_online())
+        except Exception:
+            logger.warning("reset_command_send_failed", vault_id=vault.id)
+
+        logger.info("vault_reset", vault_id=vault.id, user_id=input.requesting_user_id)
+
+        return ResetVaultResult(vault_id=vault.id)

--- a/app/domain/models/access_log.py
+++ b/app/domain/models/access_log.py
@@ -10,10 +10,12 @@ ActivityAction = Literal[
     "VAULT_UNLOCKED",
     "VAULT_UNLOCK_FAILED",
     "VAULT_STATE_CHANGED",
+    "VAULT_RESET",
     "UNLOCK_COMMAND_SENT",
     "PIN_SET",
     "MEMBER_ADDED",
     "MEMBER_REMOVED",
+    "TAMPER_DETECTED",
 ]
 
 # All valid method types describing how the action was triggered.

--- a/app/domain/models/user.py
+++ b/app/domain/models/user.py
@@ -14,3 +14,4 @@ class User:
     password_hash: str
     full_name: str | None
     created_at: datetime
+    provisioning_token: str | None = None

--- a/app/domain/value_objects/vault_status.py
+++ b/app/domain/value_objects/vault_status.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class VaultStatus(str, Enum):
+    PROVISIONING = "PROVISIONING"
     LOCKED = "LOCKED"
     UNLOCKED = "UNLOCKED"
     OFFLINE = "OFFLINE"

--- a/app/infrastructure/db/models/user_orm.py
+++ b/app/infrastructure/db/models/user_orm.py
@@ -15,6 +15,7 @@ class UserORM(Base):
     email: Mapped[str] = mapped_column(String(320), unique=True, index=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(Text, nullable=False)
     full_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    provisioning_token: Mapped[str | None] = mapped_column(String(8), nullable=True, unique=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/app/infrastructure/db/repositories/in_memory_activity_log_repository.py
+++ b/app/infrastructure/db/repositories/in_memory_activity_log_repository.py
@@ -55,3 +55,6 @@ class InMemoryActivityLogRepository(ActivityLogRepository):
             1 for l in self._logs
             if l.action == action and l.created_at >= since
         )
+
+    def delete_by_vault_id(self, vault_id: str) -> None:
+        self._logs = [log for log in self._logs if log.vault_id != vault_id]

--- a/app/infrastructure/db/repositories/in_memory_user_repository.py
+++ b/app/infrastructure/db/repositories/in_memory_user_repository.py
@@ -54,3 +54,21 @@ class InMemoryUserRepository(UserRepository):
 
     def get_by_ids(self, user_ids: list[str]) -> dict[str, User]:
         return {uid: user for uid, user in self._by_id.items() if uid in user_ids}
+
+    def get_by_provisioning_token(self, token: str) -> User | None:
+        for user in self._by_id.values():
+            if user.provisioning_token == token:
+                return user
+        return None
+
+    def set_provisioning_token(self, user_id: str, token: str) -> None:
+        user = self._by_id.get(user_id)
+        if user is None:
+            raise ValueError(f"User {user_id} not found")
+        self.save(replace(user, provisioning_token=token))
+
+    def clear_provisioning_token(self, user_id: str) -> None:
+        user = self._by_id.get(user_id)
+        if user is None:
+            raise ValueError(f"User {user_id} not found")
+        self.save(replace(user, provisioning_token=None))

--- a/app/infrastructure/db/repositories/sqlalchemy_activity_log_repository.py
+++ b/app/infrastructure/db/repositories/sqlalchemy_activity_log_repository.py
@@ -81,3 +81,7 @@ class SqlAlchemyActivityLogRepository(ActivityLogRepository):
             .where(AccessLogORM.created_at >= since)
         )
         return result or 0
+
+    def delete_by_vault_id(self, vault_id: str) -> None:
+        self._session.query(AccessLogORM).filter(AccessLogORM.vault_id == vault_id).delete()
+        self._session.commit()

--- a/app/infrastructure/db/repositories/sqlalchemy_user_repository.py
+++ b/app/infrastructure/db/repositories/sqlalchemy_user_repository.py
@@ -20,6 +20,7 @@ class SqlAlchemyUserRepository(UserRepository):
             password_hash=orm.password_hash,
             full_name=orm.full_name,
             created_at=orm.created_at,
+            provisioning_token=orm.provisioning_token,
         )
 
     def save(self, user: User) -> None:
@@ -29,6 +30,7 @@ class SqlAlchemyUserRepository(UserRepository):
             password_hash=user.password_hash,
             full_name=user.full_name,
             created_at=user.created_at,
+            provisioning_token=user.provisioning_token,
         )
         self._db.merge(orm)  # FIXED: uses self._db
         self._db.flush()     # FIXED: uses self._db
@@ -49,7 +51,8 @@ class SqlAlchemyUserRepository(UserRepository):
             email=user.email,
             password_hash=user.password_hash,
             full_name=getattr(user, "full_name", None),
-            created_at=user.created_at # Ensure created_at is passed if needed
+            created_at=user.created_at, # Ensure created_at is passed if needed
+            provisioning_token=getattr(user, "provisioning_token", None),
         )
         self._db.add(row)
         try:
@@ -96,3 +99,27 @@ class SqlAlchemyUserRepository(UserRepository):
         updated_orm = result.scalar_one_or_none()
         self._db.flush()
         return self._to_domain(updated_orm) if updated_orm else None
+
+    def get_by_provisioning_token(self, token: str) -> User | None:
+        row = (
+            self._db.query(UserORM)
+            .filter(UserORM.provisioning_token == token)
+            .one_or_none()
+        )
+        if row is None:
+            return None
+        return self._to_domain(row)
+
+    def set_provisioning_token(self, user_id: str, token: str) -> None:
+        row = self._db.get(UserORM, user_id)
+        if row is None:
+            raise ValueError(f"User {user_id} not found")
+        row.provisioning_token = token
+        self._db.commit()
+
+    def clear_provisioning_token(self, user_id: str) -> None:
+        row = self._db.get(UserORM, user_id)
+        if row is None:
+            raise ValueError(f"User {user_id} not found")
+        row.provisioning_token = None
+        self._db.commit()

--- a/app/schemas/vaults.py
+++ b/app/schemas/vaults.py
@@ -45,3 +45,38 @@ class VaultListItemResponse(BaseModel):
     last_seen_at: datetime | None
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+class ProvisioningTokenResponse(BaseModel):
+    provisioning_token: str
+
+
+class ResetVaultResponse(BaseModel):
+    reset: bool
+
+
+class RegisterDeviceRequest(BaseModel):
+    hardware_uuid: str
+    provisioning_token: str
+
+
+class RegisterDeviceResponse(BaseModel):
+    vault_id: str
+    vault_name: str | None = None
+
+
+class VerifyPINRequest(BaseModel):
+    hardware_uuid: str
+    pin: str
+
+
+class VerifyPINResponse(BaseModel):
+    unlocked: bool
+
+
+class TamperAlertRequest(BaseModel):
+    hardware_uuid: str
+
+
+class TamperAlertResponse(BaseModel):
+    received: bool

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -208,6 +208,26 @@ class _FakeUserRepo(UserRepository):
         self.save(updated)
         return updated
 
+    def get_by_provisioning_token(self, token: str):
+        for user in self._by_id.values():
+            if user.provisioning_token == token:
+                return user
+        return None
+
+    def set_provisioning_token(self, user_id: str, token: str) -> None:
+        user = self.get_by_id(user_id)
+        if not user:
+            raise ValueError(f"User {user_id} not found")
+        updated = replace(user, provisioning_token=token)
+        self.save(updated)
+
+    def clear_provisioning_token(self, user_id: str) -> None:
+        user = self.get_by_id(user_id)
+        if not user:
+            raise ValueError(f"User {user_id} not found")
+        updated = replace(user, provisioning_token=None)
+        self.save(updated)
+
 
 class _NoopRateLimiter:
     async def allow_request(self, *args, **kwargs):

--- a/app/websocket/vault_socket.py
+++ b/app/websocket/vault_socket.py
@@ -154,25 +154,92 @@ async def websocket_user_endpoint(
 async def websocket_vault_endpoint(
     websocket: WebSocket,
     hardware_uuid: str = Query(..., description="Vault hardware UUID"),
-    vault_secret: str = Query(..., description="Pre-shared vault secret"),
     repo: VaultRepository = Depends(get_vault_repo),
 ):
     """
     WebSocket endpoint for vault devices (ESP32 hardware).
-    
-    Devices can:
-    - Receive unlock/lock commands
-    - Send state updates
-    - Send heartbeats
-    - Report tamper events
-    
-    Authentication: Hardware UUID + pre-shared secret
+
+    Identified by hardware_uuid query param (no auth - firmware has no JWT).
+    Firmware sends: heartbeat, state_update, ack
+    Backend sends: remote_unlock, buzzer_off, reset
     """
-    
-    raise WebSocketException(
-        code=status.WS_1008_POLICY_VIOLATION,
-        reason="Vault device websocket not wired yet",
+    from app.api.deps.common import get_db_session
+    from app.infrastructure.db.repositories.sqlalchemy_activity_log_repository import (
+        SqlAlchemyActivityLogRepository,
     )
+    from app.application.use_cases.process_vault_state_update import ProcessVaultStateUpdate
+
+    # 1. Look up vault by hardware_uuid
+    vault = repo.get_by_hardware_uuid(hardware_uuid)
+    if vault is None:
+        await websocket.close(code=4004, reason="Device not registered")
+        return
+
+    vault_id = vault.id
+
+    # 2. Register connection
+    await manager.connect_vault(websocket, vault_id)
+
+    try:
+        while True:
+            data = await websocket.receive_text()
+
+            try:
+                message = json.loads(data)
+                msg_type = message.get("type")
+
+                if msg_type == "heartbeat":
+                    # Update heartbeat timestamp
+                    manager.last_heartbeat[vault_id] = datetime.now(timezone.utc)
+                    logger.debug(f"Heartbeat from vault {vault_id}")
+
+                elif msg_type == "state_update":
+                    new_status = message.get("status")
+                    if new_status:
+                        try:
+                            # Get a fresh DB session for this operation
+                            from app.infrastructure.db.session import SessionLocal
+
+                            db = SessionLocal()
+                            try:
+                                from app.infrastructure.db.repositories.sqlalchemy_vault_repository import (
+                                    SqlAlchemyVaultRepository,
+                                )
+                                from app.infrastructure.db.repositories.sqlalchemy_activity_log_repository import (
+                                    SqlAlchemyActivityLogRepository,
+                                )
+
+                                vault_repo_fresh = SqlAlchemyVaultRepository(db)
+                                log_repo = SqlAlchemyActivityLogRepository(db)
+                                uc = ProcessVaultStateUpdate(vault_repo_fresh, log_repo)
+                                await uc.execute(
+                                    vault_id=vault_id,
+                                    new_status=new_status,
+                                    metadata={"source": "firmware", "hardware_uuid": hardware_uuid},
+                                )
+                            finally:
+                                db.close()
+                        except Exception as e:
+                            logger.error(f"State update failed for vault {vault_id}: {e}")
+
+                elif msg_type == "ack":
+                    command = message.get("command")
+                    logger.info(f"Vault {vault_id} acked command: {command}")
+
+                else:
+                    logger.warning(f"Unknown message type from vault {vault_id}: {msg_type}")
+
+            except json.JSONDecodeError:
+                logger.error(f"Invalid JSON from vault {vault_id}")
+
+    except WebSocketDisconnect:
+        logger.info(f"Vault {vault_id} disconnected")
+
+    except Exception as e:
+        logger.error(f"WebSocket error for vault {vault_id}: {e}")
+
+    finally:
+        manager.disconnect_vault(websocket, vault_id)
 
 
 # ============================================


### PR DESCRIPTION
## Summary
Adds  column to the marynelle-aban marynelle-aban table to support the firmware provisioning flow.

## Motivation
The mobile app generates a provisioning token that the vault owner enters in the firmware captive portal. The firmware sends it to  to claim ownership of the vault.

## Changes
- Added Alembic migration  — adds  to marynelle-aban marynelle-aban

## Architecture Impact
- [x] Database migration included

## Checklist
- [x] Migration is reversible (downgrade implemented)
- [x] Nullable column — backward compatible
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Short, unique provisioning tokens for user accounts (assign, look up, clear) and device-facing endpoints for provisioning flows.
* **API**
  * Firmware-facing /devices endpoints (register, verify PIN, tamper) and vault endpoints for generating provisioning tokens and resetting vaults.
* **Use Cases**
  * Token generation, device registration, and vault reset flows with mapped error responses.
* **Domain**
  * New vault status and activity actions for provisioning, reset, and tamper events.
* **Tests**
  * Test helpers updated to support provisioning token behavior.
* **Chores**
  * Database migration to persist provisioning tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->